### PR TITLE
Allow ALB Target group names less than 32 chars.

### DIFF
--- a/terraform/030-phpmyadmin/main.tf
+++ b/terraform/030-phpmyadmin/main.tf
@@ -9,7 +9,7 @@ resource "random_id" "blowfish_secret" {
  * Create target group for ALB
  */
 resource "aws_alb_target_group" "phpmyadmin" {
-  name                 = "${substr("tg-${var.idp_name}-${var.app_name}-${var.app_env}", 0, 32)}"
+  name                 = "${replace("tg-${var.idp_name}-${var.app_name}-${var.app_env}", "/(.{0,32})(.*)/", "$1")}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -18,7 +18,7 @@ resource "aws_alb" "alb" {
  * Create target group for ALB
  */
 resource "aws_alb_target_group" "broker" {
-  name                 = "${substr("tg-${var.idp_name}-${var.app_name}-${var.app_env}", 0, 32)}"
+  name                 = "${replace("tg-${var.idp_name}-${var.app_name}-${var.app_env}", "/(.{0,32})(.*)/", "$1")}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -11,7 +11,7 @@ resource "logentries_log" "log" {
  * Create target group for ALB
  */
 resource "aws_alb_target_group" "pwmanager" {
-  name                 = "${substr("tg-${var.idp_name}-${var.app_name}-${var.app_env}", 0, 32)}"
+  name                 = "${replace("tg-${var.idp_name}-${var.app_name}-${var.app_env}", "/(.{0,32})(.*)/", "$1")}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -11,7 +11,7 @@ resource "logentries_log" "log" {
  * Create target group for ALB
  */
 resource "aws_alb_target_group" "ssp" {
-  name                 = "${substr("tg-${var.idp_name}-${var.app_name}-${var.app_env}", 0, 32)}"
+  name                 = "${replace("tg-${var.idp_name}-${var.app_name}-${var.app_env}", "/(.{0,32})(.*)/", "$1")}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -11,7 +11,7 @@ resource "logentries_log" "log" {
  * Create target group for ALB
  */
 resource "aws_alb_target_group" "idsync" {
-  name                 = "${substr("tg-${var.idp_name}-${var.app_name}-${var.app_env}", 0, 32)}"
+  name                 = "${replace("tg-${var.idp_name}-${var.app_name}-${var.app_env}", "/(.{0,32})(.*)/", "$1")}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"


### PR DESCRIPTION
I've tested this syntax locally (using `terraform console`) and it works as expected, both with strings that are too long and with strings that aren't too long (both exact length and shorter).