### PR TITLE
Add optional idp_display_name var (used in task def.).

### DIFF
--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -74,6 +74,7 @@ data "template_file" "task_def" {
     id_store_config        = "${var.id_store_config}"
     id_sync_access_tokens  = "${random_id.access_token_external.hex}"
     idp_name               = "${var.idp_name}"
+    idp_display_name       = "${var.idp_display_name}"
     logentries_key         = "${logentries_log.log.token}"
     mailer_host            = "${var.mailer_host}"
     mailer_username        = "${var.mailer_username}"

--- a/terraform/070-id-sync/task-definition.json
+++ b/terraform/070-id-sync/task-definition.json
@@ -50,6 +50,10 @@
         "value": "${idp_name}"
       },
       {
+        "name": "IDP_DISPLAY_NAME",
+        "value": "${idp_display_name}"
+      },
+      {
         "name": "LOGENTRIES_KEY",
         "value": "${logentries_key}"
       },

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -65,6 +65,11 @@ variable "idp_name" {
   type = "string"
 }
 
+variable "idp_display_name" {
+  default = ""
+  type = "string"
+}
+
 variable "ecs_cluster_id" {
   type = "string"
 }


### PR DESCRIPTION
I make the idp_display_name variable optional so that (as far as semver is concerned) this is merely adding a new feature, not a backwards-breaking API change.