### PR TITLE
Revise CPU/RAM allotments (some actual, some only defaults)

### DIFF
--- a/terraform/030-phpmyadmin/task-definition.json
+++ b/terraform/030-phpmyadmin/task-definition.json
@@ -1,7 +1,7 @@
 [
   {
     "volumesFrom": [],
-    "memory": 128,
+    "memory": 64,
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,
@@ -38,7 +38,7 @@
     "user": null,
     "dockerLabels": null,
     "logConfiguration": null,
-    "cpu": 64,
+    "cpu": 32,
     "privileged": null,
     "memoryReservation": null
   }

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -12,11 +12,11 @@ variable "cloudflare_domain" {
 }
 
 variable "cpu_api" {
-  default = "250"
+  default = "32"
 }
 
 variable "cpu_cron" {
-  default = "250"
+  default = "100"
 }
 
 variable "db_name" {
@@ -104,7 +104,7 @@ variable "memory_api" {
 }
 
 variable "memory_cron" {
-  default = "64"
+  default = "32"
 }
 
 variable "mysql_host" {

--- a/terraform/032-db-backup/vars.tf
+++ b/terraform/032-db-backup/vars.tf
@@ -9,7 +9,7 @@ variable "app_name" {
 
 variable "cpu" {
   type    = "string"
-  default = "128"
+  default = "32"
 }
 
 variable "cron_schedule" {
@@ -50,7 +50,7 @@ variable "logentries_set_id" {
 
 variable "memory" {
   type    = "string"
-  default = "64"
+  default = "32"
 }
 
 variable "mysql_host" {

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -1,9 +1,9 @@
 variable "memory" {
-  default = "96"
+  default = "200"
 }
 
 variable "memory_cron" {
-  default = "64"
+  default = "50"
 }
 
 variable "cpu" {

--- a/terraform/050-pw-manager/task-definition-api.json
+++ b/terraform/050-pw-manager/task-definition-api.json
@@ -162,7 +162,7 @@
   },
   {
     "volumesFrom": [],
-    "memory": 128,
+    "memory": 100,
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,
@@ -184,7 +184,7 @@
     "user": null,
     "dockerLabels": null,
     "logConfiguration": null,
-    "cpu": 128,
+    "cpu": 32,
     "privileged": null,
     "memoryReservation": null
   }

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -1,9 +1,9 @@
 variable "memory" {
-  default = "96"
+  default = "100"
 }
 
 variable "cpu" {
-  default = "250"
+  default = "64"
 }
 
 variable "logentries_set_id" {

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -3,7 +3,7 @@ variable "memory" {
 }
 
 variable "cpu" {
-  default = "250"
+  default = "150"
 }
 
 variable "logentries_set_id" {

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -3,7 +3,7 @@ variable "memory" {
 }
 
 variable "cpu" {
-  default = "128"
+  default = "200"
 }
 
 variable "logentries_set_id" {


### PR DESCRIPTION
Now that we have been running this code for awhile, we have some real
numbers to know what CPU and RAM requirements the variuos pieces
have. This sets the defaults (or actual values, for non-configurable
values) to what seem to be more fitting amounts.