### PR TITLE
Raise default RAM for ID Sync to avoid out-of-memory crashes

### DIFF
--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -1,5 +1,5 @@
 variable "memory" {
-  default = "128"
+  default = "200"
 }
 
 variable "cpu" {


### PR DESCRIPTION
It looks like 128 RAM can be a little too low, leading to us seeing some failed full-syncs.