### PR TITLE
Release 2.5.3

### DIFF
--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -93,7 +93,7 @@ data "template_file" "task_def" {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=1.1.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=2.2.0"
   cluster_id         = "${var.ecs_cluster_id}"
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = "${var.app_env}"


### PR DESCRIPTION
**Fixed:**
- Raise default RAM for ID Sync to avoid out-of-memory crashes