### PR TITLE
Make region more dynamic

### DIFF
--- a/terraform/000-core/README.md
+++ b/terraform/000-core/README.md
@@ -15,6 +15,10 @@ IAM roles to function.
  - `app_name` - Name of application, ex: Doorman, IdP, etc.
  - `app_env` - Name of environment, ex: prod, test, etc.
 
+## Optional Inputs
+
+ - `aws_region` - Region to deploy in, ex: `us-east-1`
+
 ## Outputs
 
  - `cduser_access_key_id` - AWS access key id for continuous delivery user

--- a/terraform/000-core/README.md
+++ b/terraform/000-core/README.md
@@ -18,6 +18,7 @@ IAM roles to function.
 ## Optional Inputs
 
  - `aws_region` - Region to deploy in, ex: `us-east-1`
+ - `enable_cloudtrail` - Whether to create a Trail for this in AWS CloudTrail
 
 ## Outputs
 

--- a/terraform/000-core/README.md
+++ b/terraform/000-core/README.md
@@ -18,7 +18,7 @@ IAM roles to function.
 ## Optional Inputs
 
  - `aws_region` - Region to deploy in, ex: `us-east-1`
- - `enable_cloudtrail` - Whether to create a Trail for this in AWS CloudTrail
+ - `enable_cloudtrail` - Whether to create a Trail for this in AWS CloudTrail (`yes` or `no`)
 
 ## Outputs
 

--- a/terraform/000-core/main.tf
+++ b/terraform/000-core/main.tf
@@ -146,7 +146,7 @@ EOF
  * Create CloudTrail resources
  */
 resource "aws_s3_bucket" "cloudtrail" {
-  bucket        = "${var.app_name}-${var.app_env}-cloudtrail"
+  bucket        = "${var.app_name}-${var.app_env}-cloudtrail-${var.aws_region}"
   force_destroy = true
 
   policy = <<POLICY

--- a/terraform/000-core/main.tf
+++ b/terraform/000-core/main.tf
@@ -124,7 +124,7 @@ resource "aws_iam_user_policy" "cd_serverless" {
                 "logs:*"
             ],
             "Resource": [
-                "arn:aws:logs:us-east-1:*:log-group:*:log-stream:"
+                "arn:aws:logs:${var.aws_region}:*:log-group:*:log-stream:"
             ]
         },
         {

--- a/terraform/000-core/vars.tf
+++ b/terraform/000-core/vars.tf
@@ -9,6 +9,11 @@ variable "app_env" {
   type = "string"
 }
 
+variable "aws_region" {
+  default = "us-east-1"
+  type    = "string"
+}
+
 variable "enable_cloudtrail" {
   type    = "string"
   default = "yes"

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -45,10 +45,32 @@ module "asg" {
 }
 
 /*
- * Get ssl cert for use with listener
+ * Create ssl cert for use with listener
  */
-data "aws_acm_certificate" "wildcard" {
+resource "aws_acm_certificate" "wildcard" {
+  domain_name       = "${var.cert_domain_name}"
+  validation_method = "DNS"
+
+  tags {
+    app_name = "${var.app_name}"
+    app_env  = "${var.app_env}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_record" "cert_validation_dns_record" {
   domain = "${var.cert_domain_name}"
+  name   = "${aws_acm_certificate.wildcard.domain_validation_options.0.resource_record_name}"
+  value  = "${aws_acm_certificate.wildcard.domain_validation_options.0.resource_record_value}"
+  type   = "${aws_acm_certificate.wildcard.domain_validation_options.0.resource_record_type}"
+}
+
+resource "aws_acm_certificate_validation" "wildcard_cert_validation" {
+  certificate_arn = "${aws_acm_certificate.wildcard.arn}"
+  validation_record_fqdns = ["${cloudflare_record.cert_validation_dns_record.hostname}"]
 }
 
 /*
@@ -62,7 +84,7 @@ module "alb" {
   vpc_id          = "${module.vpc.id}"
   security_groups = ["${module.vpc.vpc_default_sg_id}", "${module.cloudflare-sg.id}"]
   subnets         = ["${module.vpc.public_subnet_ids}"]
-  certificate_arn = "${data.aws_acm_certificate.wildcard.arn}"
+  certificate_arn = "${aws_acm_certificate.wildcard.arn}"
 }
 
 /*
@@ -78,7 +100,7 @@ module "internal_alb" {
   vpc_id          = "${module.vpc.id}"
   security_groups = ["${module.vpc.vpc_default_sg_id}"]
   subnets         = ["${module.vpc.private_subnet_ids}"]
-  certificate_arn = "${data.aws_acm_certificate.wildcard.arn}"
+  certificate_arn = "${aws_acm_certificate.wildcard.arn}"
 }
 
 /*


### PR DESCRIPTION
**Summary:**
- Changed a hardcoded `us-east-1` to be dynamic in a generated policy
- Added `aws_region` parameter (defaulting to `us-east-1` so by default nothing changes for the modified policy)
- Added region to S3 bucket name used by CloudTrail (to avoid naming conflicts when trying to bring up an IdP in a different region)