### PR TITLE
Release 6.1.0

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -243,7 +243,6 @@ services:
       API_ACCESS_KEYS: abc123
       APP_NAME: email-service
       FROM_EMAIL: "dummy@example.com"
-      FROM_NAME: Test
       NOTIFICATION_EMAIL: "dummy@example.com"
       MYSQL_ROOT_PASSWORD: not-a-secret
       MYSQL_HOST: db-email
@@ -260,7 +259,6 @@ services:
       APP_ENV: dev
       APP_NAME: email-service
       FROM_EMAIL: "dummy@example.com"
-      FROM_NAME: Test
       NOTIFICATION_EMAIL: "dummy@example.com"
       MYSQL_ROOT_PASSWORD: not-a-secret
       MYSQL_HOST: db-email

--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -20,7 +20,6 @@ This module is used to create an ECS service running email-service.
  - `email_brand_color` - CSS color to use for branding in emails
  - `email_brand_logo` - The fully qualified URL to an image for logo in emails
  - `from_email` - Email address to send emails from
- - `from_name` - Email address to send emails from
  - `idp_name` - Short name of IdP for use in logs and email alerts
  - `internal_alb_dns_name` - DNS name for the IdP-in-a-Box's internal Application Load Balancer
  - `internal_alb_listener_arn` - ARN for the IdP-in-a-Box's internal ALB's listener
@@ -76,7 +75,6 @@ module "email" {
   email_brand_logo          = "${var.email_brand_logo}"
   email_queue_batch_size    = "${var.email_queue_batch_size}"
   from_email                = "${var.from_email}"
-  from_name                 = "${var.from_name}"
   idp_name                  = "${var.idp_name}"
   internal_alb_dns_name     = "${data.terraform_remote_state.cluster.internal_alb_dns_name}"
   internal_alb_listener_arn = "${data.terraform_remote_state.cluster.internal_alb_https_listener_arn}"

--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -71,7 +71,6 @@ data "template_file" "task_def_api" {
     email_brand_logo          = var.email_brand_logo
     email_queue_batch_size    = var.email_queue_batch_size
     from_email                = var.from_email
-    from_name                 = var.from_name
     idp_name                  = var.idp_name
     mailer_host               = var.mailer_host
     mailer_password           = var.mailer_password
@@ -114,7 +113,6 @@ data "template_file" "task_def_cron" {
     email_brand_logo          = var.email_brand_logo
     email_queue_batch_size    = var.email_queue_batch_size
     from_email                = var.from_email
-    from_name                 = var.from_name
     idp_name                  = var.idp_name
     mailer_host               = var.mailer_host
     mailer_password           = var.mailer_password

--- a/terraform/031-email-service/task-definition-api.json
+++ b/terraform/031-email-service/task-definition-api.json
@@ -50,10 +50,6 @@
         "value": "${from_email}"
       },
       {
-        "name": "FROM_NAME",
-        "value": "${from_name}"
-      },
-      {
         "name": "IDP_NAME",
         "value": "${idp_name}"
       },

--- a/terraform/031-email-service/task-definition-cron.json
+++ b/terraform/031-email-service/task-definition-cron.json
@@ -44,10 +44,6 @@
         "value": "${from_email}"
       },
       {
-        "name": "FROM_NAME",
-        "value": "${from_name}"
-      },
-      {
         "name": "IDP_NAME",
         "value": "${idp_name}"
       },

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -69,10 +69,6 @@ variable "from_email" {
   type = string
 }
 
-variable "from_name" {
-  type = string
-}
-
 variable "idp_name" {
   type = string
 }

--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -96,7 +96,7 @@ resource "aws_iam_user_policy" "ci_ui" {
         "cloudfront:CreateInvalidation"
       ],
       "Resource": [
-        aws_cloudfront_distribution.ui[0].arn
+        "${aws_cloudfront_distribution.ui[0].arn}"
       ]
     },
     {

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -54,6 +54,8 @@ data "template_file" "task_def" {
   vars = {
     memory                       = var.memory
     cpu                          = var.cpu
+    admin_email                  = var.admin_email
+    admin_name                   = var.admin_name
     admin_pass                   = random_id.admin_pass.hex
     app_env                      = var.app_env
     app_name                     = var.app_name

--- a/terraform/060-simplesamlphp/task-definition.json
+++ b/terraform/060-simplesamlphp/task-definition.json
@@ -23,11 +23,11 @@
     "environment": [
       {
         "name": "ADMIN_EMAIL",
-        "value": "info@insitehome.org"
+        "value": "${admin_email}"
       },
       {
         "name": "ADMIN_NAME",
-        "value": "Insite Admin"
+        "value": "${admin_name}"
       },
       {
         "name": "ADMIN_PASS",

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -188,3 +188,8 @@ variable "help_center_url" {
   type = string
 }
 
+variable "admin_email" {
+}
+
+variable "admin_name" {
+}


### PR DESCRIPTION
- syntax error fixed
- removed `from_name`: not used by email_service
- added `admin_name` and `admin_email`: variables are defined in TF cloud workspaces but weren't passed into the task definition