### PR TITLE
Release 6.6.0

### DIFF
--- a/terraform/000-core/main.tf
+++ b/terraform/000-core/main.tf
@@ -2,7 +2,7 @@
  * Create ECS cluster
  */
 module "ecscluster" {
-  source   = "github.com/silinternational/terraform-modules//aws/ecs/cluster?ref=3.3.0"
+  source   = "github.com/silinternational/terraform-modules//aws/ecs/cluster?ref=3.3.2"
   app_name = var.app_name
   app_env  = var.app_env
 }

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -2,7 +2,7 @@
  * Create VPC
  */
 module "vpc" {
-  source    = "github.com/silinternational/terraform-modules//aws/vpc?ref=3.3.0"
+  source    = "github.com/silinternational/terraform-modules//aws/vpc?ref=3.3.2"
   app_name  = var.app_name
   app_env   = var.app_env
   aws_zones = var.aws_zones
@@ -12,7 +12,7 @@ module "vpc" {
  * Security group to limit traffic to Cloudflare IPs
  */
 module "cloudflare-sg" {
-  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=3.3.0"
+  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=3.3.2"
   vpc_id = module.vpc.id
 }
 
@@ -33,7 +33,7 @@ data "aws_ami" "ecs_ami" {
  * Create auto-scaling group
  */
 module "asg" {
-  source                  = "github.com/silinternational/terraform-modules//aws/asg?ref=3.3.0"
+  source                  = "github.com/silinternational/terraform-modules//aws/asg?ref=3.3.2"
   app_name                = var.app_name
   app_env                 = var.app_env
   aws_instance            = var.aws_instance
@@ -56,7 +56,7 @@ data "aws_acm_certificate" "wildcard" {
  * Create application load balancer for public access
  */
 module "alb" {
-  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=3.3.0"
+  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=3.3.2"
   app_name        = var.app_name
   app_env         = var.app_env
   internal        = "false"
@@ -70,7 +70,7 @@ module "alb" {
  * Create application load balancer for internal use
  */
 module "internal_alb" {
-  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=3.3.0"
+  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=3.3.2"
   alb_name        = "alb-${var.app_name}-${var.app_env}-int"
   app_name        = var.app_name
   app_env         = var.app_env

--- a/terraform/020-database/main.tf
+++ b/terraform/020-database/main.tf
@@ -7,7 +7,7 @@ resource "random_id" "db_root_pass" {
 }
 
 module "rds" {
-  source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=3.3.0"
+  source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=3.3.2"
   app_name                = var.app_name
   app_env                 = var.app_env
   db_name                 = var.db_name

--- a/terraform/021-elasticache/main.tf
+++ b/terraform/021-elasticache/main.tf
@@ -2,7 +2,7 @@
  * Create Memcache cluster
  */
 module "memcache" {
-  source               = "github.com/silinternational/terraform-modules//aws/elasticache/memcache?ref=3.3.0"
+  source               = "github.com/silinternational/terraform-modules//aws/elasticache/memcache?ref=3.3.2"
   cluster_id           = "${var.app_name}-${var.app_env}-cache"
   security_group_ids   = var.security_group_ids
   subnet_group_name    = "${var.app_name}-${var.app_env}-cache-subnet"

--- a/terraform/022-ecr/main.tf
+++ b/terraform/022-ecr/main.tf
@@ -2,7 +2,7 @@
  * id-broker
  */
 module "ecr_idbroker" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.0"
+  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.2"
   repo_name           = "${var.idp_name}/id-broker"
   ecsInstanceRole_arn = var.ecsInstanceRole_arn
   ecsServiceRole_arn  = var.ecsServiceRole_arn
@@ -13,7 +13,7 @@ module "ecr_idbroker" {
  * email-service
  */
 module "ecr_emailservice" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.0"
+  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.2"
   repo_name           = "${var.idp_name}/email-service"
   ecsInstanceRole_arn = var.ecsInstanceRole_arn
   ecsServiceRole_arn  = var.ecsServiceRole_arn
@@ -24,7 +24,7 @@ module "ecr_emailservice" {
  * pw-api
  */
 module "ecr_pwapi" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.0"
+  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.2"
   repo_name           = "${var.idp_name}/pw-api"
   ecsInstanceRole_arn = var.ecsInstanceRole_arn
   ecsServiceRole_arn  = var.ecsServiceRole_arn
@@ -35,7 +35,7 @@ module "ecr_pwapi" {
  * simplesamlphp
  */
 module "ecr_simplesamlphp" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.0"
+  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.2"
   repo_name           = "${var.idp_name}/simplesamlphp"
   ecsInstanceRole_arn = var.ecsInstanceRole_arn
   ecsServiceRole_arn  = var.ecsServiceRole_arn
@@ -46,7 +46,7 @@ module "ecr_simplesamlphp" {
  * id-sync
  */
 module "ecr_idsync" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.0"
+  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.2"
   repo_name           = "${var.idp_name}/id-sync"
   ecsInstanceRole_arn = var.ecsInstanceRole_arn
   ecsServiceRole_arn  = var.ecsServiceRole_arn
@@ -57,7 +57,7 @@ module "ecr_idsync" {
  * db-backup
  */
 module "ecr_dbbackup" {
-  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.0"
+  source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.3.2"
   repo_name           = "${var.idp_name}/db-backup"
   ecsInstanceRole_arn = var.ecsInstanceRole_arn
   ecsServiceRole_arn  = var.ecsServiceRole_arn

--- a/terraform/030-phpmyadmin/main.tf
+++ b/terraform/030-phpmyadmin/main.tf
@@ -51,7 +51,7 @@ data "template_file" "task_def" {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env

--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -85,7 +85,7 @@ data "template_file" "task_def_api" {
 }
 
 module "ecsservice_api" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-api"
   service_env        = var.app_env
@@ -127,7 +127,7 @@ data "template_file" "task_def_cron" {
 }
 
 module "ecsservice_cron" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-no-alb?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-no-alb?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-cron"
   service_env        = var.app_env

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -176,7 +176,7 @@ data "template_file" "task_def" {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -110,7 +110,7 @@ data "template_file" "task_def" {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env

--- a/terraform/060-simplesamlphp/README.md
+++ b/terraform/060-simplesamlphp/README.md
@@ -64,7 +64,7 @@ This module is used to create an ECS service running simpleSAMLphp.
 
 ```hcl
 module "cf_ips" {
-  source = "github.com/silinternational/terraform-modules//cloudflare/ips?ref=3.3.0"
+  source = "github.com/silinternational/terraform-modules//cloudflare/ips?ref=3.3.2"
 }
 
 module "ssp" {

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -99,7 +99,7 @@ data "template_file" "task_def" {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -89,7 +89,7 @@ data "template_file" "task_def" {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.0"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.3.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env


### PR DESCRIPTION
use terraform-modules 3.3.2 - Add dynamic tags support to asg and rds
(3.3.0 was accidentally released before merging the feature into master)