### PR TITLE
Release 7.0.1

### DIFF
--- a/terraform/021-elasticache/outputs.tf
+++ b/terraform/021-elasticache/outputs.tf
@@ -2,7 +2,7 @@
  * Elasticache outputs
  */
 output "cache_nodes" {
-  value = [module.memcache.cache_nodes]
+  value = module.memcache.cache_nodes
 }
 
 output "cache_configuration_endpoint" {


### PR DESCRIPTION
cache_nodes is already a list, so the brackets created a nested list