### PR TITLE
Provider updates

### DIFF
--- a/terraform/000-core/main.tf
+++ b/terraform/000-core/main.tf
@@ -160,9 +160,9 @@ resource "aws_acm_certificate" "idp" {
 
 resource "cloudflare_record" "idp-verification" {
   count   = var.create_acm_cert ? 1 : 0
-  name    = aws_acm_certificate.idp[0].domain_validation_options[0].resource_record_name
-  value   = aws_acm_certificate.idp[0].domain_validation_options[0].resource_record_value
-  type    = aws_acm_certificate.idp[0].domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.idp[0].domain_validation_options)[0].resource_record_name
+  value   = tolist(aws_acm_certificate.idp[0].domain_validation_options)[0].resource_record_value
+  type    = tolist(aws_acm_certificate.idp[0].domain_validation_options)[0].resource_record_type
   zone_id = data.cloudflare_zones.idp.zones[0].id
   proxied = false
 }

--- a/terraform/000-core/versions.tf
+++ b/terraform/000-core/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/000-core/versions.tf
+++ b/terraform/000-core/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
   }
 }

--- a/terraform/010-cluster/versions.tf
+++ b/terraform/010-cluster/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/010-cluster/versions.tf
+++ b/terraform/010-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/020-database/versions.tf
+++ b/terraform/020-database/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/020-database/versions.tf
+++ b/terraform/020-database/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2.0, < 4.0.0"
     }
   }
 }

--- a/terraform/020-database/versions.tf
+++ b/terraform/020-database/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/021-elasticache/versions.tf
+++ b/terraform/021-elasticache/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/021-elasticache/versions.tf
+++ b/terraform/021-elasticache/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/022-ecr/versions.tf
+++ b/terraform/022-ecr/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/022-ecr/versions.tf
+++ b/terraform/022-ecr/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/030-phpmyadmin/versions.tf
+++ b/terraform/030-phpmyadmin/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/030-phpmyadmin/versions.tf
+++ b/terraform/030-phpmyadmin/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
   }
 }

--- a/terraform/031-email-service/versions.tf
+++ b/terraform/031-email-service/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/031-email-service/versions.tf
+++ b/terraform/031-email-service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/031-email-service/versions.tf
+++ b/terraform/031-email-service/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2.0, < 4.0.0"
     }
   }
 }

--- a/terraform/032-db-backup/versions.tf
+++ b/terraform/032-db-backup/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/032-db-backup/versions.tf
+++ b/terraform/032-db-backup/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/040-id-broker/versions.tf
+++ b/terraform/040-id-broker/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/040-id-broker/versions.tf
+++ b/terraform/040-id-broker/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/040-id-broker/versions.tf
+++ b/terraform/040-id-broker/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2.0, < 4.0.0"
     }
   }
 }

--- a/terraform/041-id-broker-search-lambda/versions.tf
+++ b/terraform/041-id-broker-search-lambda/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/041-id-broker-search-lambda/versions.tf
+++ b/terraform/041-id-broker-search-lambda/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/050-pw-manager/versions.tf
+++ b/terraform/050-pw-manager/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/050-pw-manager/versions.tf
+++ b/terraform/050-pw-manager/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/050-pw-manager/versions.tf
+++ b/terraform/050-pw-manager/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2.0, < 4.0.0"
     }
   }
 }

--- a/terraform/060-simplesamlphp/versions.tf
+++ b/terraform/060-simplesamlphp/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/060-simplesamlphp/versions.tf
+++ b/terraform/060-simplesamlphp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/060-simplesamlphp/versions.tf
+++ b/terraform/060-simplesamlphp/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2.0, < 4.0.0"
     }
   }
 }

--- a/terraform/070-id-sync/versions.tf
+++ b/terraform/070-id-sync/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -8,7 +8,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 4.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/070-id-sync/versions.tf
+++ b/terraform/070-id-sync/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.61"
+      version = "~> 3.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/070-id-sync/versions.tf
+++ b/terraform/070-id-sync/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2.0, < 4.0.0"
     }
   }
 }


### PR DESCRIPTION
### Fixed
- Upgraded AWS provider to `"~> 3.0"`
- Upgraded random provider to `">= 2.2.0, < 4.0.0"`
- Upgraded cloudflare provider to `">= 2.0.0, < 4.0.0"` (requires Terraform version 0.14 or later)

--
Note: tested on staging IDP