### PR TITLE
Double things up in 010-cluster for a secondary AWS region

### DIFF
--- a/terraform/010-cluster/README.md
+++ b/terraform/010-cluster/README.md
@@ -23,26 +23,47 @@ ssl certificate, core application load balancer, and a CloudWatch log group
  - `ecs_instance_profile_id` - IAM profile ID for ecsInstanceProfile
  - `idp_name` - Name of the IDP (all lowercase, no spaces), example: `acme`
 
+## Optional Inputs
+
+- `aws_region_secondary` - A string with a secondary region to deploy in, example: `us-east-1`
+- `aws_zones_secondary` -  A list of availability zones to distribute secondary instances across, example: `["us-east-1a", "us-east-1b", "us-east-1c"]`
+
 
 ## Outputs
 
  - `aws_zones` - The list of zones deployed in
+ - `aws_zones_secondary` - The list of secondary zones deployed in
  - `cloudflare_sg_id` - Security group ID for Cloudflare HTTPS access
+ - `cloudflare_sg_id_secondary` - Secondary security group ID for Cloudflare HTTPS access
  - `db_subnet_group_name` - Database subnet group name
+ - `db_subnet_group_name_secondary` - Secondary database subnet group name
  - `nat_gateway_ip` - NAT gateway elastic IP address
- - `private_subnet_ids` - List of private subnet ids in VPC
+ - `nat_gateway_ip_secondary` - Secondary NAT gateway elastic IP address
  - `private_subnet_cidr_blocks` - A list of private subnet CIDR blocks, ex: `["10.0.11.0/24","10.0.22.0/24"]`
- - `public_subnet_ids` - List of public subnet ids in VPC
+ - `private_subnet_cidr_blocks_secondary` - A list of secondary private subnet CIDR blocks, ex: `["10.0.11.0/24","10.0.22.0/24"]`
+ - `private_subnet_ids` - List of private subnet ids in VPC
+ - `private_subnet_ids_secondary` - List of secondary private subnet ids in VPC
  - `public_subnet_cidr_blocks` - A list of public subnet CIDR blocks, ex: `["10.0.10.0/24","10.0.12.0/24"]`
+ - `public_subnet_cidr_blocks_secondary` - A list of secondary public subnet CIDR blocks, ex: `["10.0.10.0/24","10.0.12.0/24"]`
+ - `public_subnet_ids` - List of public subnet ids in VPC
+ - `public_subnet_ids_secondary` - List of secondary public subnet ids in VPC
  - `vpc_default_sg_id` - The default security group ID for the VPC
+ - `vpc_default_sg_id_secondary` - The default security group ID for the secondary VPC
  - `vpc_id` - ID for the VPC
+ - `vpc_id_secondary` - ID for the secondary VPC
  - `alb_arn` - ARN for application load balancer
+ - `alb_arn_secondary` - ARN for secondary application load balancer
  - `alb_default_tg_arn` - ARN for default target group on load balancer
+ - `alb_default_tg_arn_secondary` - ARN for default target group on secondary load balancer
  - `alb_dns_name` - DNS name for ALB
+ - `alb_dns_name_secondary` - DNS name for secondary ALB
  - `alb_https_listener_arn` - ARN for HTTPS listener on ALB
+ - `alb_https_listener_arn_secondary` - ARN for HTTPS listener on secondary ALB
  - `alb_id` - ID for ALB
+ - `alb_id_secondary` - ID for secondary ALB
  - `wildcard_cert_arn` - ARN to wildcard ACM certificate
  - `cloudwatch_log_group_name` - Name of the CloudWatch log group
+ - `cloudwatch_log_group_name_secondary` - Name of the secondary CloudWatch log group
  
 ## Example Usage
 

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -9,11 +9,33 @@ module "vpc" {
 }
 
 /*
+ * Create secondary VPC
+ */
+module "vpc_secondary" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  source    = "github.com/silinternational/terraform-modules//aws/vpc?ref=8.1.0"
+  app_name  = var.app_name
+  app_env   = var.app_env
+  aws_zones = var.aws_zones_secondary
+}
+
+/*
  * Security group to limit traffic to Cloudflare IPs
  */
 module "cloudflare-sg" {
   source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=8.1.0"
   vpc_id = module.vpc.id
+}
+
+/*
+ * Secondary vpc security group to limit traffic to Cloudflare IPs
+ */
+module "cloudflare-sg_secondary" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=8.1.0"
+  vpc_id = module.vpc_secondary.id
 }
 
 /*
@@ -47,6 +69,25 @@ module "asg" {
 }
 
 /*
+ * Create secondary auto-scaling group
+ */
+module "asg_secondary" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  source                  = "github.com/silinternational/terraform-modules//aws/asg?ref=8.1.0"
+  app_name                = var.app_name
+  app_env                 = var.app_env
+  aws_instance            = var.aws_instance
+  private_subnet_ids      = module.vpc_secondary.private_subnet_ids
+  default_sg_id           = module.vpc_secondary.vpc_default_sg_id
+  ecs_instance_profile_id = var.ecs_instance_profile_id
+  ecs_cluster_name        = var.ecs_cluster_name
+  ami_id                  = data.aws_ami.ecs_ami.id
+  additional_user_data    = var.asg_additional_user_data
+  tags                    = var.tags
+}
+
+/*
  * Get ssl cert for use with listener
  */
 data "aws_acm_certificate" "wildcard" {
@@ -68,6 +109,22 @@ module "alb" {
 }
 
 /*
+ * Create secondary application load balancer for public access
+ */
+module "alb_secondary" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=8.1.0"
+  app_name        = var.app_name
+  app_env         = var.app_env
+  internal        = "false"
+  vpc_id          = module.vpc_secondary.id
+  security_groups = [module.vpc_secondary.vpc_default_sg_id, module.cloudflare-sg.id]
+  subnets         = module.vpc_secondary.public_subnet_ids
+  certificate_arn = data.aws_acm_certificate.wildcard.arn
+}
+
+/*
  * Create application load balancer for internal use
  */
 module "internal_alb" {
@@ -84,10 +141,43 @@ module "internal_alb" {
 }
 
 /*
+ * Create application load balancer for internal use
+ */
+module "internal_alb_secondary" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=8.1.0"
+  alb_name        = "alb-${var.app_name}-${var.app_env}-secondary-int"
+  app_name        = var.app_name
+  app_env         = var.app_env
+  internal        = "true"
+  tg_name         = "tg-${var.app_name}-${var.app_env}-secondary-int-def"
+  vpc_id          = module.vpc_secondary.id
+  security_groups = [module.vpc_secondary.vpc_default_sg_id]
+  subnets         = module.vpc_secondary.private_subnet_ids
+  certificate_arn = data.aws_acm_certificate.wildcard.arn
+}
+
+/*
  * Create Cloudwatch log group
  */
 resource "aws_cloudwatch_log_group" "logs" {
   name              = "idp-${var.idp_name}-${var.app_env}"
+  retention_in_days = 30
+
+  tags = {
+    idp_name = var.idp_name
+    app_env  = var.app_env
+  }
+}
+
+/*
+ * Create secondary Cloudwatch log group
+ */
+resource "aws_cloudwatch_log_group" "logs_secondary" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  name              = "idp-${var.idp_name}-${var.app_env}-secondary"
   retention_in_days = 30
 
   tags = {
@@ -119,5 +209,32 @@ module "ecs-service-cloudwatch-dashboard" {
   ]
 
   aws_region = var.aws_region
+}
+
+/*
+ * Create secondary CloudWatch Dashboard for services that will be in this cluster
+ */
+module "ecs-service-cloudwatch-dashboard" {
+  count = var.aws_region_secondary == "" ? 0 : 1
+
+  source  = "silinternational/ecs-service-cloudwatch-dashboard/aws"
+  version = "~> 2.0.0"
+
+  cluster_name   = var.ecs_cluster_name
+  dashboard_name = "${var.app_name}-${var.app_env}-secondary"
+
+  service_names = [
+    "${var.idp_name}-db-backup",
+    "${var.idp_name}-email-service-api",
+    "${var.idp_name}-email-service-cron",
+    "${var.idp_name}-id-broker",
+    "${var.idp_name}-id-broker-cron",
+    "${var.idp_name}-id-sync",
+    "${var.idp_name}-phpmyadmin",
+    "${var.idp_name}-pw-manager",
+    "${var.idp_name}-simplesamlphp",
+  ]
+
+  aws_region = var.aws_region_secondary
 }
 

--- a/terraform/010-cluster/outputs.tf
+++ b/terraform/010-cluster/outputs.tf
@@ -5,40 +5,80 @@ output "aws_zones" {
   value = module.vpc.aws_zones
 }
 
+output "aws_zones_secondary" {
+  value = module.vpc_secondary.aws_zones
+}
+
 output "cloudflare_sg_id" {
   value = module.cloudflare-sg.id
+}
+
+output "cloudflare_sg_id_secondary" {
+  value = module.cloudflare-sg_secondary.id
 }
 
 output "db_subnet_group_name" {
   value = module.vpc.db_subnet_group_name
 }
 
+output "db_subnet_group_name_secondary" {
+  value = module.vpc_secondary.db_subnet_group_name
+}
+
 output "nat_gateway_ip" {
   value = module.vpc.nat_gateway_ip
+}
+
+output "nat_gateway_ip_secondary" {
+  value = module.vpc_secondary.nat_gateway_ip
 }
 
 output "private_subnet_ids" {
   value = module.vpc.private_subnet_ids
 }
 
+output "private_subnet_ids_secondary" {
+  value = module.vpc_secondary.private_subnet_ids
+}
+
 output "public_subnet_ids" {
   value = module.vpc.public_subnet_ids
+}
+
+output "public_subnet_ids_secondary" {
+  value = module.vpc_secondary.public_subnet_ids
 }
 
 output "vpc_default_sg_id" {
   value = module.vpc.vpc_default_sg_id
 }
 
+output "vpc_default_sg_id_secondary" {
+  value = module.vpc_secondary.vpc_default_sg_id
+}
+
 output "vpc_id" {
   value = module.vpc.id
+}
+
+output "vpc_id_secondary" {
+  value = module.vpc_secondary.id
 }
 
 output "public_subnet_cidr_blocks" {
   value = module.vpc.public_subnet_cidr_blocks
 }
 
+output "public_subnet_cidr_blocks_secondary" {
+  value = module.vpc_secondary.public_subnet_cidr_blocks
+}
+
 output "private_subnet_cidr_blocks" {
   value = module.vpc.private_subnet_cidr_blocks
+}
+
+output "private_subnet_cidr_blocks_secondary" {
+  value = module.vpc_secondary.private_subnet_cidr_blocks
 }
 
 /*
@@ -47,21 +87,40 @@ output "private_subnet_cidr_blocks" {
 output "alb_arn" {
   value = module.alb.arn
 }
+output "alb_arn_secondary" {
+  value = module.alb_secondary.arn
+}
 
 output "alb_default_tg_arn" {
   value = module.alb.default_tg_arn
+}
+
+output "alb_default_tg_arn_secondary" {
+  value = module.alb_secondary.default_tg_arn
 }
 
 output "alb_dns_name" {
   value = module.alb.dns_name
 }
 
+output "alb_dns_name_secondary" {
+  value = module.alb_secondary.dns_name
+}
+
 output "alb_https_listener_arn" {
   value = module.alb.https_listener_arn
 }
 
+output "alb_https_listener_arn_secondary" {
+  value = module.alb_secondary.https_listener_arn
+}
+
 output "alb_id" {
   value = module.alb.id
+}
+
+output "alb_id_secondary" {
+  value = module.alb_secondary.id
 }
 
 /*
@@ -71,20 +130,40 @@ output "internal_alb_arn" {
   value = module.internal_alb.arn
 }
 
+output "internal_alb_arn_secondary" {
+  value = module.internal_alb_secondary.arn
+}
+
 output "internal_alb_default_tg_arn" {
   value = module.internal_alb.default_tg_arn
+}
+
+output "internal_alb_default_tg_arn_secondary" {
+  value = module.internal_alb_secondary.default_tg_arn
 }
 
 output "internal_alb_dns_name" {
   value = module.internal_alb.dns_name
 }
 
+output "internal_alb_dns_name_secondary" {
+  value = module.internal_alb_secondary.dns_name
+}
+
 output "internal_alb_https_listener_arn" {
   value = module.internal_alb.https_listener_arn
 }
 
+output "internal_alb_https_listener_arn_secondary" {
+  value = module.internal_alb_secondary.https_listener_arn
+}
+
 output "internal_alb_id" {
   value = module.internal_alb.id
+}
+
+output "internal_alb_id_secondary" {
+  value = module.internal_alb_secondary.id
 }
 
 /*
@@ -96,5 +175,9 @@ output "wildcard_cert_arn" {
 
 output "cloudwatch_log_group_name" {
   value = aws_cloudwatch_log_group.logs.name
+}
+
+output "cloudwatch_log_group_name_secondary" {
+  value = aws_cloudwatch_log_group.logs_secondary.name
 }
 

--- a/terraform/010-cluster/vars.tf
+++ b/terraform/010-cluster/vars.tf
@@ -17,8 +17,19 @@ variable "aws_region" {
   type = string
 }
 
+variable "aws_region_secondary" {
+  description = "secondary AWS region - leave blank if a secondary region is not desired"
+  default     = ""
+  type        = string
+}
+
 variable "aws_zones" {
   type = list(string)
+}
+
+variable "aws_zones_secondary" {
+  type = list(string)
+  default = []
 }
 
 variable "cert_domain_name" {


### PR DESCRIPTION
Am I right in thinking that the `ssl cert for use with listener` does not need to be doubled up?

Also, when do we decide if this is the right strategy vs. doing it with separate Tfm workspaces in mind.