### PR TITLE
add resources now required to make a new public-access bucket

### DIFF
--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -25,6 +25,21 @@ resource "aws_s3_bucket_policy" "ui" {
   })
 }
 
+resource "aws_s3_bucket_ownership_controls" "ui" {
+  bucket = aws_s3_bucket.ui.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "ui" {
+  bucket                  = aws_s3_bucket.ui.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
 resource "aws_s3_bucket_website_configuration" "ui" {
   bucket = aws_s3_bucket.ui.id
   index_document {


### PR DESCRIPTION
AWS recently made a new requirement that certain configurations must be in place in order to make an S3 bucket public-accessible. This PR adds those resources for the pw-ui bucket.