### PR TITLE
fix db backup

### DIFF
--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -14,6 +14,25 @@ resource "aws_s3_bucket" "backup" {
 resource "aws_s3_bucket_acl" "backup" {
   bucket = aws_s3_bucket.backup.id
   acl    = "private"
+  depends_on = [
+    aws_s3_bucket_ownership_controls.backup,
+    aws_s3_bucket_public_access_block.backup,
+  ]
+}
+
+resource "aws_s3_bucket_ownership_controls" "backup" {
+  bucket = aws_s3_bucket.backup.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "backup" {
+  bucket                  = aws_s3_bucket.backup.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "backup" {

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_versioning" "backup" {
  * Create user for putting backup files into the bucket
  */
 resource "aws_iam_user" "backup" {
-  name = "db-backup-${var.idp_name}-${var.app_env}"
+  name = var.backup_user_name == null ? "db-backup-${var.idp_name}-${var.app_env}" : var.backup_user_name
 }
 
 resource "aws_iam_access_key" "backup" {

--- a/terraform/032-db-backup/vars.tf
+++ b/terraform/032-db-backup/vars.tf
@@ -11,6 +11,11 @@ variable "aws_region" {
   type = string
 }
 
+variable "backup_user_name" {
+  type    = string
+  default = null
+}
+
 variable "cloudwatch_log_group_name" {
   type = string
 }

--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -9,6 +9,10 @@ resource "aws_s3_bucket" "ui" {
 resource "aws_s3_bucket_acl" "ui" {
   bucket = aws_s3_bucket.ui.id
   acl    = "public-read"
+  depends_on = [
+    aws_s3_bucket_ownership_controls.ui,
+    aws_s3_bucket_public_access_block.ui,
+  ]
 }
 
 resource "aws_s3_bucket_policy" "ui" {


### PR DESCRIPTION
### Added
- AWS recently made a new requirement that certain configurations must be in place in order to make an S3 bucket public-accessible. This PR adds those resources for the db-backup bucket.
- Added a variable backup_user_name to avoid a naming conflict on the secondary user.