### PR TITLE
Add a variable to allow overwrite of DNS record

### DIFF
--- a/terraform/000-core/main.tf
+++ b/terraform/000-core/main.tf
@@ -79,14 +79,12 @@ resource "cloudflare_record" "idp-verification" {
   name    = tolist(aws_acm_certificate.idp[0].domain_validation_options)[0].resource_record_name
   value   = tolist(aws_acm_certificate.idp[0].domain_validation_options)[0].resource_record_value
   type    = tolist(aws_acm_certificate.idp[0].domain_validation_options)[0].resource_record_type
-  zone_id = data.cloudflare_zones.idp.zones[0].id
+  zone_id = data.cloudflare_zone.domain.id
   proxied = false
 }
 
-data "cloudflare_zones" "idp" {
-  filter {
-    name = var.cert_domain
-  }
+data "cloudflare_zone" "domain" {
+  name = var.cert_domain
 }
 
 resource "aws_acm_certificate_validation" "idp" {

--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -41,11 +41,12 @@ This module is used to create an ECS service running email-service.
  - `cpu_api` - CPU resources to allot to each API instance
  - `cpu_cron` - CPU resources to allot to the cron instance
  - `desired_count_api` - Desired count of email-service API instances (there will only be 1 cron instance)
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
  - `email_queue_batch_size` - How many queued emails to process per run
+ - `enable_cron` - Set to false to disable the cron instance
  - `mailer_usefiles` - Whether or not YiiMailer should write to files instead of sending emails
  - `memory_api` - Memory (RAM) resources to allot to each API instance
  - `memory_cron` - Memory (RAM) resources to allot to the cron instance
- - `enable_cron` - Set to false to disable the cron instance
 
 ## Outputs
 

--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -41,7 +41,7 @@ This module is used to create an ECS service running email-service.
  - `cpu_api` - CPU resources to allot to each API instance
  - `cpu_cron` - CPU resources to allot to the cron instance
  - `desired_count_api` - Desired count of email-service API instances (there will only be 1 cron instance)
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `email_queue_batch_size` - How many queued emails to process per run
  - `enable_cron` - Set to false to disable the cron instance
  - `mailer_usefiles` - Whether or not YiiMailer should write to files instead of sending emails

--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -131,17 +131,14 @@ module "ecsservice_cron" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "emaildns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
-  name    = var.subdomain
-  value   = var.internal_alb_dns_name
-  type    = "CNAME"
-  proxied = false
+  zone_id         = data.cloudflare_zone.domain.name
+  name            = var.subdomain
+  value           = var.internal_alb_dns_name
+  type            = "CNAME"
+  proxied         = false
+  allow_overwrite = var.dns_allow_overwrite
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.cloudflare_domain
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
 }

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -143,3 +143,9 @@ variable "wildcard_cert_arn" {
 variable "enable_cron" {
   default = true
 }
+
+variable "dns_allow_overwrite" {
+  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
+  type        = bool
+  default     = false
+}

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -53,6 +53,7 @@ This module is used to create an ECS service running id-broker.
  - `abandoned_user_deactivate_instructions_url` - URL for instruction on how to deactivate user accounts, referenced in notification email. Default: (none)
  - `contingent_user_duration` - How long before a new user without a primary email address expires. Default: `+4 weeks`
  - `cpu_cron` - How much CPU to allocate to cron service. Default: `128`
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
  - `email_repeat_delay_days` - Don't resend the same type of email to the same user for X days. Default: `31`
  - `email_service_assertValidIp` - Whether or not to assert IP address for Email Service API is trusted
  - `email_signature` - Signature for use in emails. Default is empty string

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -53,7 +53,7 @@ This module is used to create an ECS service running id-broker.
  - `abandoned_user_deactivate_instructions_url` - URL for instruction on how to deactivate user accounts, referenced in notification email. Default: (none)
  - `contingent_user_duration` - How long before a new user without a primary email address expires. Default: `+4 weeks`
  - `cpu_cron` - How much CPU to allocate to cron service. Default: `128`
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `email_repeat_delay_days` - Don't resend the same type of email to the same user for X days. Default: `31`
  - `email_service_assertValidIp` - Whether or not to assert IP address for Email Service API is trusted
  - `email_signature` - Signature for use in emails. Default is empty string

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -397,17 +397,14 @@ resource "aws_cloudwatch_event_target" "broker_event_target" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "brokerdns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
-  name    = var.subdomain
-  value   = var.internal_alb_dns_name
-  type    = "CNAME"
-  proxied = false
+  zone_id         = data.cloudflare_zone.domain.name
+  name            = var.subdomain
+  value           = var.internal_alb_dns_name
+  type            = "CNAME"
+  proxied         = false
+  allow_overwrite = var.dns_allow_overwrite
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.cloudflare_domain
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
 }

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -572,3 +572,8 @@ variable "wildcard_cert_arn" {
   type = string
 }
 
+variable "dns_allow_overwrite" {
+  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
+  type        = bool
+  default     = false
+}

--- a/terraform/050-pw-manager/README.md
+++ b/terraform/050-pw-manager/README.md
@@ -60,6 +60,7 @@ This module is used to create an ECS service running the password manager API an
 ## Optional Inputs
 
  - `code_length` - Number of digits in reset code. Default: `6`
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
  - `extra_hosts` - Extra hosts for the API task definition, e.g. "\["hostname":"host.example.com","ipAddress":"192.168.1.1"\]"
  - `password_rule_enablehibp` - Enable haveibeenpwned.com password check. Default: `true`
  - `password_rule_maxlength` - Maximum password length. Default: `255`

--- a/terraform/050-pw-manager/README.md
+++ b/terraform/050-pw-manager/README.md
@@ -60,7 +60,7 @@ This module is used to create an ECS service running the password manager API an
 ## Optional Inputs
 
  - `code_length` - Number of digits in reset code. Default: `6`
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `extra_hosts` - Extra hosts for the API task definition, e.g. "\["hostname":"host.example.com","ipAddress":"192.168.1.1"\]"
  - `password_rule_enablehibp` - Enable haveibeenpwned.com password check. Default: `true`
  - `password_rule_maxlength` - Maximum password length. Default: `255`

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -119,17 +119,15 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "apidns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
-  name    = var.api_subdomain
-  value   = var.alb_dns_name
-  type    = "CNAME"
-  proxied = true
+  zone_id         = data.cloudflare_zone.domain.name
+  name            = var.api_subdomain
+  value           = var.alb_dns_name
+  type            = "CNAME"
+  proxied         = true
+  allow_overwrite = var.dns_allow_overwrite
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.cloudflare_domain
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
 }
+

--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -151,13 +151,15 @@ resource "aws_iam_user_policy" "ci_ui" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "uidns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
-  name    = var.ui_subdomain
-  value   = aws_cloudfront_distribution.ui[0].domain_name
-  type    = "CNAME"
-  proxied = true
+  zone_id         = data.cloudflare_zone.domain.name
+  name            = var.ui_subdomain
+  value           = aws_cloudfront_distribution.ui[0].domain_name
+  type            = "CNAME"
+  proxied         = true
+  allow_overwrite = var.dns_allow_overwrite
 }
 
-locals {
-  ui_hostname = "${var.ui_subdomain}.${var.cloudflare_domain}"
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
 }
+

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -264,3 +264,8 @@ variable "wildcard_cert_arn" {
   type = string
 }
 
+variable "dns_allow_overwrite" {
+  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
+  type        = bool
+  default     = false
+}

--- a/terraform/060-simplesamlphp/README.md
+++ b/terraform/060-simplesamlphp/README.md
@@ -45,6 +45,7 @@ This module is used to create an ECS service running simpleSAMLphp.
 ## Optional Inputs
 
  - `delete_remember_me_on_logout` - Whether or not to delete remember me cookie on logout. Default: `false`
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
  - `enable_debug` - Enable debug logs. Default: `false`
  - `logging_level` - Minimum log level to log. DO NOT use DEBUG in production. Allowed values: ERR, WARNING, NOTICE, INFO, DEBUG. Default: `NOTICE`
  - `mfa_learn_more_url` - URL to learn more about 2SV during profile review. Default: (link not displayed)

--- a/terraform/060-simplesamlphp/README.md
+++ b/terraform/060-simplesamlphp/README.md
@@ -45,7 +45,7 @@ This module is used to create an ECS service running simpleSAMLphp.
 ## Optional Inputs
 
  - `delete_remember_me_on_logout` - Whether or not to delete remember me cookie on logout. Default: `false`
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
+ - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `enable_debug` - Enable debug logs. Default: `false`
  - `logging_level` - Minimum log level to log. DO NOT use DEBUG in production. Allowed values: ERR, WARNING, NOTICE, INFO, DEBUG. Default: `NOTICE`
  - `mfa_learn_more_url` - URL to learn more about 2SV during profile review. Default: (link not displayed)

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -115,17 +115,14 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "sspdns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
-  name    = var.subdomain
-  value   = var.alb_dns_name
-  type    = "CNAME"
-  proxied = true
+  zone_id         = data.cloudflare_zone.domain.name
+  name            = var.subdomain
+  value           = var.alb_dns_name
+  type            = "CNAME"
+  proxied         = true
+  allow_overwrite = var.dns_allow_overwrite
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.cloudflare_domain
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
 }

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -194,3 +194,9 @@ variable "admin_name" {
 variable "trust_cloudflare_ips" {
   default = ""
 }
+
+variable "dns_allow_overwrite" {
+  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
+  type        = bool
+  default     = false
+}

--- a/terraform/070-id-sync/README.md
+++ b/terraform/070-id-sync/README.md
@@ -44,7 +44,7 @@ store.
 - `notifier_email_to` - Who to send notifications to about sync problems (e.g. users lacking email addresses)
 - `sync_safety_cutoff` - The percentage of records allowed to be changed during a sync, provided as a float, ex: `0.2` for `20%`
 - `allow_empty_email` - Whether or not to allow the primary email property to be empty. Default: `false`
-- `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
+- `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
 - `enable_new_user_notification` - Enable email notification to HR Contact upon creation of a new user, if set to 'true'. Default: `false`
 - `enable_sync` - Set to false to disable the sync process.
 

--- a/terraform/070-id-sync/README.md
+++ b/terraform/070-id-sync/README.md
@@ -44,6 +44,7 @@ store.
 - `notifier_email_to` - Who to send notifications to about sync problems (e.g. users lacking email addresses)
 - `sync_safety_cutoff` - The percentage of records allowed to be changed during a sync, provided as a float, ex: `0.2` for `20%`
 - `allow_empty_email` - Whether or not to allow the primary email property to be empty. Default: `false`
+- `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP.
 - `enable_new_user_notification` - Enable email notification to HR Contact upon creation of a new user, if set to 'true'. Default: `false`
 - `enable_sync` - Set to false to disable the sync process.
 

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -97,17 +97,15 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "idsyncdns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
-  name    = var.subdomain
-  value   = var.alb_dns_name
-  type    = "CNAME"
-  proxied = true
+  zone_id         = data.cloudflare_zone.domain.name
+  name            = var.subdomain
+  value           = var.alb_dns_name
+  type            = "CNAME"
+  proxied         = true
+  allow_overwrite = var.dns_allow_overwrite
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.cloudflare_domain
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
 }
+

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -141,3 +141,9 @@ variable "enable_new_user_notification" {
 variable "enable_sync" {
   default = true
 }
+
+variable "dns_allow_overwrite" {
+  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Added
- In each module that creates a CNAME record for an ECS service, added a new variable `dns_allow_overwrite` that provides the ability to overwrite an existing DNS record. This would be necessary in a multiregion failover when the primary workspace is not operational.

### Changed (non-breaking)
- Use the simpler `cloudflare_zone` data source instead of `cloudflare_zones`.