### PR TITLE
add new variable create_dns_record to control creation of CNAME for ECS

### DIFF
--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -40,6 +40,7 @@ This module is used to create an ECS service running email-service.
  - `app_name` - Application name
  - `cpu_api` - CPU resources to allot to each API instance
  - `cpu_cron` - CPU resources to allot to the cron instance
+ - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `desired_count_api` - Desired count of email-service API instances (there will only be 1 cron instance)
  - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `email_queue_batch_size` - How many queued emails to process per run

--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -131,6 +131,8 @@ module "ecsservice_cron" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "emaildns" {
+  count = var.create_dns_record ? 1 : 0
+
   zone_id         = data.cloudflare_zone.domain.name
   name            = var.subdomain
   value           = var.internal_alb_dns_name

--- a/terraform/031-email-service/outputs.tf
+++ b/terraform/031-email-service/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value = cloudflare_record.emaildns.hostname
+  value = one(cloudflare_record.emaildns[*].hostname)
 }
 
 output "db_emailservice_user" {

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -144,6 +144,12 @@ variable "enable_cron" {
   default = true
 }
 
+variable "create_dns_record" {
+  description = "Controls creation of a DNS CNAME record for the ECS service."
+  type        = bool
+  default     = true
+}
+
 variable "dns_allow_overwrite" {
   description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
   type        = bool

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -53,6 +53,7 @@ This module is used to create an ECS service running id-broker.
  - `abandoned_user_deactivate_instructions_url` - URL for instruction on how to deactivate user accounts, referenced in notification email. Default: (none)
  - `contingent_user_duration` - How long before a new user without a primary email address expires. Default: `+4 weeks`
  - `cpu_cron` - How much CPU to allocate to cron service. Default: `128`
+ - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `email_repeat_delay_days` - Don't resend the same type of email to the same user for X days. Default: `31`
  - `email_service_assertValidIp` - Whether or not to assert IP address for Email Service API is trusted

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -397,6 +397,8 @@ resource "aws_cloudwatch_event_target" "broker_event_target" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "brokerdns" {
+  count = var.create_dns_record ? 1 : 0
+
   zone_id         = data.cloudflare_zone.domain.name
   name            = var.subdomain
   value           = var.internal_alb_dns_name

--- a/terraform/040-id-broker/outputs.tf
+++ b/terraform/040-id-broker/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value = cloudflare_record.brokerdns.hostname
+  value = one(cloudflare_record.brokerdns[*].hostname)
 }
 
 output "db_idbroker_user" {

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -572,6 +572,12 @@ variable "wildcard_cert_arn" {
   type = string
 }
 
+variable "create_dns_record" {
+  description = "Controls creation of a DNS CNAME record for the ECS service."
+  type        = bool
+  default     = true
+}
+
 variable "dns_allow_overwrite" {
   description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
   type        = bool

--- a/terraform/050-pw-manager/README.md
+++ b/terraform/050-pw-manager/README.md
@@ -60,6 +60,7 @@ This module is used to create an ECS service running the password manager API an
 ## Optional Inputs
 
  - `code_length` - Number of digits in reset code. Default: `6`
+ - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `extra_hosts` - Extra hosts for the API task definition, e.g. "\["hostname":"host.example.com","ipAddress":"192.168.1.1"\]"
  - `password_rule_enablehibp` - Enable haveibeenpwned.com password check. Default: `true`

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -119,6 +119,8 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "apidns" {
+  count = var.create_dns_record ? 1 : 0
+
   zone_id         = data.cloudflare_zone.domain.name
   name            = var.api_subdomain
   value           = var.alb_dns_name

--- a/terraform/050-pw-manager/outputs.tf
+++ b/terraform/050-pw-manager/outputs.tf
@@ -11,7 +11,7 @@ output "ui_hostname" {
 }
 
 output "api_hostname" {
-  value = cloudflare_record.apidns.hostname
+  value = one(cloudflare_record.apidns[*].hostname)
 }
 
 output "db_pwmanager_user" {

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -264,6 +264,12 @@ variable "wildcard_cert_arn" {
   type = string
 }
 
+variable "create_dns_record" {
+  description = "Controls creation of a DNS CNAME record for the ECS service."
+  type        = bool
+  default     = true
+}
+
 variable "dns_allow_overwrite" {
   description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
   type        = bool

--- a/terraform/060-simplesamlphp/README.md
+++ b/terraform/060-simplesamlphp/README.md
@@ -44,6 +44,7 @@ This module is used to create an ECS service running simpleSAMLphp.
 
 ## Optional Inputs
 
+ - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `delete_remember_me_on_logout` - Whether or not to delete remember me cookie on logout. Default: `false`
  - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `enable_debug` - Enable debug logs. Default: `false`

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -115,6 +115,8 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "sspdns" {
+  count = var.create_dns_record ? 1 : 0
+
   zone_id         = data.cloudflare_zone.domain.name
   name            = var.subdomain
   value           = var.alb_dns_name

--- a/terraform/060-simplesamlphp/outputs.tf
+++ b/terraform/060-simplesamlphp/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value = cloudflare_record.sspdns.hostname
+  value = one(cloudflare_record.sspdns[*].hostname)
 }
 
 output "db_ssp_user" {

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -195,6 +195,12 @@ variable "trust_cloudflare_ips" {
   default = ""
 }
 
+variable "create_dns_record" {
+  description = "Controls creation of a DNS CNAME record for the ECS service."
+  type        = bool
+  default     = true
+}
+
 variable "dns_allow_overwrite" {
   description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
   type        = bool

--- a/terraform/070-id-sync/README.md
+++ b/terraform/070-id-sync/README.md
@@ -44,6 +44,7 @@ store.
 - `notifier_email_to` - Who to send notifications to about sync problems (e.g. users lacking email addresses)
 - `sync_safety_cutoff` - The percentage of records allowed to be changed during a sync, provided as a float, ex: `0.2` for `20%`
 - `allow_empty_email` - Whether or not to allow the primary email property to be empty. Default: `false`
+- `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
 - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
 - `enable_new_user_notification` - Enable email notification to HR Contact upon creation of a new user, if set to 'true'. Default: `false`
 - `enable_sync` - Set to false to disable the sync process.

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -97,6 +97,8 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "idsyncdns" {
+  count = var.create_dns_record ? 1 : 0
+
   zone_id         = data.cloudflare_zone.domain.name
   name            = var.subdomain
   value           = var.alb_dns_name

--- a/terraform/070-id-sync/outputs.tf
+++ b/terraform/070-id-sync/outputs.tf
@@ -1,5 +1,5 @@
 output "idsync_url" {
-  value = cloudflare_record.idsyncdns.hostname
+  value = one(cloudflare_record.idsyncdns[*].hostname)
 }
 
 output "access_token_external" {

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -142,6 +142,12 @@ variable "enable_sync" {
   default = true
 }
 
+variable "create_dns_record" {
+  description = "Controls creation of a DNS CNAME record for the ECS service."
+  type        = bool
+  default     = true
+}
+
 variable "dns_allow_overwrite" {
   description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
   type        = bool


### PR DESCRIPTION
### Added
- In each module that creates a CNAME record for an ECS service, added a new variable `create_dns_record` that provides the ability to disable creation of the record. This would be set to false on the secondary region until failover time.
