### PR TITLE
remove duplicate cloudflare_zone

### DIFF
--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -158,8 +158,3 @@ resource "cloudflare_record" "uidns" {
   proxied         = true
   allow_overwrite = var.dns_allow_overwrite
 }
-
-data "cloudflare_zone" "domain" {
-  name = var.cloudflare_domain
-}
-


### PR DESCRIPTION
### Fixed
- Remove duplicate `cloudflare_zone` data source added by copy-paste. There are two very similar pieces of code in the same module, but only one had a `cloudflare_zones` before the change in #177.

https://itse.youtrack.cloud/issue/IDP-657