### PR TITLE
find DNS record by name (not include subdomain)

### DIFF
--- a/cmd/cli/multiregion/dns.go
+++ b/cmd/cli/multiregion/dns.go
@@ -100,7 +100,7 @@ func (d *DnsCommand) setCloudflareCname(name, value string) {
 
 	ctx := context.Background()
 
-	r, _, err := d.cfClient.ListDNSRecords(ctx, d.cfZone, cloudflare.ListDNSRecordsParams{Name: name + "." + d.domainName})
+	r, _, err := d.cfClient.ListDNSRecords(ctx, d.cfZone, cloudflare.ListDNSRecordsParams{Name: name})
 	if err != nil {
 		log.Fatalf("error finding DNS record %s: %s", name, err)
 	}


### PR DESCRIPTION
### Fixed
- Find API DNS records by name only, not including the domain.