### PR TITLE
Use the new way to create a public S3 bucket for the pw-manager ui

### DIFF
--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -6,7 +6,28 @@ resource "aws_s3_bucket" "ui" {
   force_destroy = true
 }
 
+resource "aws_s3_bucket_public_access_block" "ui" {
+  bucket = aws_s3_bucket.ui.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "ui" {
+  bucket = aws_s3_bucket.ui.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "ui" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.ui,
+    aws_s3_bucket_ownership_controls.ui,
+  ]
+
   bucket = aws_s3_bucket.ui.id
   acl    = "public-read"
 }


### PR DESCRIPTION
This is in response to AWS's change that, by default, blocks public access and disables ACLs. This commit follows the minimum steps necessary (as far as I can tell) to continue to set up our public ui bucket to have the same permissions we were giving it before. My changes were based on this information from Hashicorp about these changes and the effects on their "aws" provider:
https://github.com/hashicorp/terraform-provider-aws/issues/28353

The "ObjectWriter" ownership value was chosen because that's what our existing IDP pw-manager ui buckets currently have on S3.

I expect us to remove all of these ui-bucket related terraform resources when we move to using Cloudflare for the pw-manager ui.