### PR TITLE
Get db-backup S3 permission fixes (into develop, from main)

### DIFF
--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -13,8 +13,8 @@ resource "aws_s3_bucket" "backup" {
 }
 
 resource "aws_s3_bucket_acl" "backup" {
-  bucket = aws_s3_bucket.backup.id
-  acl    = "private"
+  bucket     = aws_s3_bucket.backup.id
+  acl        = "private"
   depends_on = [aws_s3_bucket_ownership_controls.backup]
 }
 

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -11,22 +11,11 @@ resource "aws_s3_bucket" "backup" {
     app_env  = var.app_env
   }
 }
-resource "aws_s3_bucket_ownership_controls" "backup" {
-  bucket = aws_s3_bucket.backup.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
 
 resource "aws_s3_bucket_acl" "backup" {
-  depends_on = [aws_s3_bucket_ownership_controls.backup]
-
   bucket = aws_s3_bucket.backup.id
   acl    = "private"
-  depends_on = [
-    aws_s3_bucket_ownership_controls.backup,
-    aws_s3_bucket_public_access_block.backup,
-  ]
+  depends_on = [aws_s3_bucket_ownership_controls.backup]
 }
 
 resource "aws_s3_bucket_ownership_controls" "backup" {
@@ -34,14 +23,6 @@ resource "aws_s3_bucket_ownership_controls" "backup" {
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
-}
-
-resource "aws_s3_bucket_public_access_block" "backup" {
-  bucket                  = aws_s3_bucket.backup.id
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "backup" {


### PR DESCRIPTION
### Fixed
- Use new S3 permissions syntax
- Clean up duplicate terraform resource blocks after merging S3 fix back into `develop`

---
This is all to fix our terraform code to cooperate with AWS's recent change to disable ACLs (and block public access) by default. We want to explicitly set this S3 bucket to private-access-only, which requires the `aws_s3_bucket_ownership_controls` additional terraform resource to allow us to set that ACL.

Since the db-backup S3 bucket is private, I believe we don't need the `aws_s3_bucket_public_access_block` resource (as per [this example](https://github.com/hashicorp/terraform-provider-aws/issues/28353).