### PR TITLE
Tfm cli tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+# IntelliJ folder
 .idea/
+
+# Go executable for the Terraform Cloud cli
+cmd/go-exe/
+
 *.env
 google-auth.json
 .terraform/

--- a/cmd/build-cli.sh
+++ b/cmd/build-cli.sh
@@ -1,0 +1,4 @@
+mkdir -p go-exe
+go build -o go-exe ./cli/...
+echo "If using a idp-cli.toml file, create it in the ./go-exe folder"
+echo "Run '$ cd ./go-exe && ./cli multiregion help'"

--- a/cmd/cli/multiregion/multiregion.go
+++ b/cmd/cli/multiregion/multiregion.go
@@ -28,20 +28,31 @@ func SetupMultiregionCmd(parentCommand *cobra.Command) {
 	var domainName string
 	multiregionCmd.PersistentFlags().StringVar(&domainName, "domain-name", "", "Domain name")
 	if err := viper.BindPFlag("domain-name", multiregionCmd.PersistentFlags().Lookup("domain-name")); err != nil {
-		log.Fatalln("Error: unable to bind flag:", err)
+		outputFlagError(multiregionCmd, err)
 	}
 
 	var env string
 	multiregionCmd.PersistentFlags().StringVar(&env, "env", "prod", "Execution environment (default: prod)")
 	if err := viper.BindPFlag("env", multiregionCmd.PersistentFlags().Lookup("env")); err != nil {
-		log.Fatalln("Error: unable to bind flag:", err)
+		outputFlagError(multiregionCmd, err)
 	}
 
 	var region2 string
 	multiregionCmd.PersistentFlags().StringVar(&region2, "region2", "", "Secondary AWS region")
 	if err := viper.BindPFlag("region2", multiregionCmd.PersistentFlags().Lookup("region2")); err != nil {
-		log.Fatalln("Error: unable to bind flag:", err)
+		outputFlagError(multiregionCmd, err)
 	}
+
+	var tfcToken string
+	multiregionCmd.PersistentFlags().StringVar(&tfcToken, "tfc-token", "", "Token for Terraform Cloud authentication")
+	if err := viper.BindPFlag("tfc-token", multiregionCmd.PersistentFlags().Lookup("tfc-token")); err != nil {
+		outputFlagError(multiregionCmd, err)
+	}
+}
+
+func outputFlagError(cmd *cobra.Command, err error) {
+	cmd.Help()
+	log.Fatalln("Error: unable to bind flag:", err)
 }
 
 type PersistentFlags struct {
@@ -66,8 +77,9 @@ func getPersistentFlags() PersistentFlags {
 
 func getRequiredParam(key string) string {
 	value := viper.GetString(key)
+
 	if value == "" {
-		log.Fatalf("parameter %[1]s is not set, use --%[1]s on command line or include in idp-cli file", key)
+		log.Fatalf("parameter %[1]s is not set, use --%[1]s on command line or include in idp-cli.toml file", key)
 	}
 	return value
 }

--- a/cmd/cli/multiregion/setup.go
+++ b/cmd/cli/multiregion/setup.go
@@ -341,7 +341,9 @@ func getWorkspaceConsumers(pFlags PersistentFlags, workspace string) []string {
 			databaseSecondaryWorkspace(pFlags),
 			pmaSecondaryWorkspace(pFlags),
 			emailSecondaryWorkspace(pFlags),
+			backupWorkspace(pFlags),
 			brokerSecondaryWorkspace(pFlags),
+			searchWorkspace(pFlags),
 			pwSecondaryWorkspace(pFlags),
 			sspSecondaryWorkspace(pFlags),
 			syncSecondaryWorkspace(pFlags),
@@ -352,11 +354,13 @@ func getWorkspaceConsumers(pFlags PersistentFlags, workspace string) []string {
 		databaseSecondaryWorkspace(pFlags): {
 			pmaSecondaryWorkspace(pFlags),
 			emailSecondaryWorkspace(pFlags),
+			backupWorkspace(pFlags),
 			brokerSecondaryWorkspace(pFlags),
 			pwSecondaryWorkspace(pFlags),
 			sspSecondaryWorkspace(pFlags),
 		},
 		ecrWorkspace(pFlags): {
+			emailSecondaryWorkspace(pFlags),
 			brokerSecondaryWorkspace(pFlags),
 			pwSecondaryWorkspace(pFlags),
 			sspSecondaryWorkspace(pFlags),
@@ -368,6 +372,7 @@ func getWorkspaceConsumers(pFlags PersistentFlags, workspace string) []string {
 			syncSecondaryWorkspace(pFlags),
 		},
 		brokerSecondaryWorkspace(pFlags): {
+			searchWorkspace(pFlags),
 			pwSecondaryWorkspace(pFlags),
 			sspSecondaryWorkspace(pFlags),
 			syncSecondaryWorkspace(pFlags),


### PR DESCRIPTION
- Add missing dependent TfC workspaces
- Add bash file to create cli executable
- If there is an error about a Nil Persistent Flag, output the help text as well as the error message
- Enable --tfc-token cli flag