### PR TITLE
Include region in aws_iam_role.ecs_events to avoid naming conflict

### DIFF
--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -313,7 +313,7 @@ locals {
  * Create role for scheduled running of cron task definitions.
  */
 resource "aws_iam_role" "ecs_events" {
-  name = "ecs_events-${var.idp_name}-${var.app_name}-${var.app_env}"
+  name = "ecs_events-${var.idp_name}-${var.app_name}-${var.app_env}-${var.aws_region}"
 
   assume_role_policy = jsonencode(
     {


### PR DESCRIPTION
### Fixed
- Include region in aws_iam_role.ecs_events to avoid naming conflict