### PR TITLE
Remove dns_allow_overwrite and corrections to README files

### DIFF
--- a/terraform/000-core/README.md
+++ b/terraform/000-core/README.md
@@ -11,13 +11,11 @@ used by later workspaces for HTTPS with the ALB.
 
 ## Required Inputs
 
- - `app_name` - Name of application, ex: Doorman, IdP, etc.
- - `app_env` - Name of environment, ex: prod, test, etc.
+ - `cluster_name` - Name of ECS cluster, typically the app name (e.g.: "idp-acme") and app env (e.g.: "prod") separated by a hyphen.
  - `cert_domain` - The TLD for the certificate domain.
 
 ## Optional Inputs
 
- - `aws_region` - Region to deploy in, ex: `us-east-1`
  - `create_acm_cert` - Set to true if an ACM certificate is needed. Default: `false`
  - `create_cd_user` - Set to false if an IAM user for continuous deployment is not needed. Default: `true`
 
@@ -28,6 +26,7 @@ used by later workspaces for HTTPS with the ALB.
  - `cduser_arn` - ARN for continuous delivery IAM user
  - `cduser_username` - Username for contiuous delivery IAM user
  - `ecs_ami_id` - The ID for the latest ECS optimized AMI
+ - `ecs_cluster_id` - The ECS cluster ID
  - `ecs_cluster_name` - The ECS cluster name
  - `ecs_instance_profile_id` - The ID for created IAM profile `ecsInstanceProfile`
  - `ecsInstanceRole_arn` - The ARN for created IAM role `ecsInstanceRole`

--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -42,7 +42,6 @@ This module is used to create an ECS service running email-service.
  - `cpu_cron` - CPU resources to allot to the cron instance
  - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `desired_count_api` - Desired count of email-service API instances (there will only be 1 cron instance)
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `email_queue_batch_size` - How many queued emails to process per run
  - `enable_cron` - Set to false to disable the cron instance
  - `mailer_usefiles` - Whether or not YiiMailer should write to files instead of sending emails

--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -133,12 +133,11 @@ module "ecsservice_cron" {
 resource "cloudflare_record" "emaildns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id         = data.cloudflare_zone.domain.id
-  name            = var.subdomain
-  value           = var.internal_alb_dns_name
-  type            = "CNAME"
-  proxied         = false
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.subdomain
+  value   = var.internal_alb_dns_name
+  type    = "CNAME"
+  proxied = false
 }
 
 data "cloudflare_zone" "domain" {

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -149,9 +149,3 @@ variable "create_dns_record" {
   type        = bool
   default     = true
 }
-
-variable "dns_allow_overwrite" {
-  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
-  type        = bool
-  default     = false
-}

--- a/terraform/032-db-backup/README.md
+++ b/terraform/032-db-backup/README.md
@@ -24,6 +24,7 @@ This module is used to run mysqldump and backup files to S3
 ## Optional Inputs
 
  - `app_name` - Application name
+ - `backup_user_name` - Name of IAM user for S3 access. Default: `db-backup-${var.idp_name}-${var.app_env}`
  - `cpu` - CPU resources to allot to each task instance
  - `cron_schedule` - Schedule for CRON execution. Default: `cron(0 2 * * ? *)`
  - `db_names` - List of database names to backup. Default: `["emailservice", "idbroker", "pwmanager", "ssp"]`

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -54,7 +54,6 @@ This module is used to create an ECS service running id-broker.
  - `contingent_user_duration` - How long before a new user without a primary email address expires. Default: `+4 weeks`
  - `cpu_cron` - How much CPU to allocate to cron service. Default: `128`
  - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `email_repeat_delay_days` - Don't resend the same type of email to the same user for X days. Default: `31`
  - `email_service_assertValidIp` - Whether or not to assert IP address for Email Service API is trusted
  - `email_signature` - Signature for use in emails. Default is empty string

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -399,12 +399,11 @@ resource "aws_cloudwatch_event_target" "broker_event_target" {
 resource "cloudflare_record" "brokerdns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id         = data.cloudflare_zone.domain.id
-  name            = var.subdomain
-  value           = var.internal_alb_dns_name
-  type            = "CNAME"
-  proxied         = false
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.subdomain
+  value   = var.internal_alb_dns_name
+  type    = "CNAME"
+  proxied = false
 }
 
 data "cloudflare_zone" "domain" {

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -577,9 +577,3 @@ variable "create_dns_record" {
   type        = bool
   default     = true
 }
-
-variable "dns_allow_overwrite" {
-  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
-  type        = bool
-  default     = false
-}

--- a/terraform/050-pw-manager/README.md
+++ b/terraform/050-pw-manager/README.md
@@ -61,7 +61,6 @@ This module is used to create an ECS service running the password manager API an
 
  - `code_length` - Number of digits in reset code. Default: `6`
  - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `extra_hosts` - Extra hosts for the API task definition, e.g. "\["hostname":"host.example.com","ipAddress":"192.168.1.1"\]"
  - `password_rule_enablehibp` - Enable haveibeenpwned.com password check. Default: `true`
  - `password_rule_maxlength` - Maximum password length. Default: `255`

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -121,12 +121,11 @@ module "ecsservice" {
 resource "cloudflare_record" "apidns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id         = data.cloudflare_zone.domain.id
-  name            = var.api_subdomain
-  value           = var.alb_dns_name
-  type            = "CNAME"
-  proxied         = true
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.api_subdomain
+  value   = var.alb_dns_name
+  type    = "CNAME"
+  proxied = true
 }
 
 data "cloudflare_zone" "domain" {

--- a/terraform/050-pw-manager/main-ui.tf
+++ b/terraform/050-pw-manager/main-ui.tf
@@ -156,10 +156,9 @@ resource "aws_iam_user_policy" "ci_ui" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "uidns" {
-  zone_id         = data.cloudflare_zone.domain.id
-  name            = var.ui_subdomain
-  value           = aws_cloudfront_distribution.ui[0].domain_name
-  type            = "CNAME"
-  proxied         = true
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.ui_subdomain
+  value   = aws_cloudfront_distribution.ui[0].domain_name
+  type    = "CNAME"
+  proxied = true
 }

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -269,9 +269,3 @@ variable "create_dns_record" {
   type        = bool
   default     = true
 }
-
-variable "dns_allow_overwrite" {
-  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
-  type        = bool
-  default     = false
-}

--- a/terraform/060-simplesamlphp/README.md
+++ b/terraform/060-simplesamlphp/README.md
@@ -46,7 +46,6 @@ This module is used to create an ECS service running simpleSAMLphp.
 
  - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `delete_remember_me_on_logout` - Whether or not to delete remember me cookie on logout. Default: `false`
- - `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
  - `enable_debug` - Enable debug logs. Default: `false`
  - `logging_level` - Minimum log level to log. DO NOT use DEBUG in production. Allowed values: ERR, WARNING, NOTICE, INFO, DEBUG. Default: `NOTICE`
  - `mfa_learn_more_url` - URL to learn more about 2SV during profile review. Default: (link not displayed)

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -119,12 +119,11 @@ module "ecsservice" {
 resource "cloudflare_record" "sspdns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id         = data.cloudflare_zone.domain.id
-  name            = var.subdomain
-  value           = var.alb_dns_name
-  type            = "CNAME"
-  proxied         = true
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.subdomain
+  value   = var.alb_dns_name
+  type    = "CNAME"
+  proxied = true
 }
 
 data "cloudflare_zone" "domain" {

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -200,9 +200,3 @@ variable "create_dns_record" {
   type        = bool
   default     = true
 }
-
-variable "dns_allow_overwrite" {
-  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
-  type        = bool
-  default     = false
-}

--- a/terraform/070-id-sync/README.md
+++ b/terraform/070-id-sync/README.md
@@ -45,7 +45,6 @@ store.
 - `sync_safety_cutoff` - The percentage of records allowed to be changed during a sync, provided as a float, ex: `0.2` for `20%`
 - `allow_empty_email` - Whether or not to allow the primary email property to be empty. Default: `false`
 - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
-- `dns_allow_overwrite` - Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP. Default: `false`
 - `enable_new_user_notification` - Enable email notification to HR Contact upon creation of a new user, if set to 'true'. Default: `false`
 - `enable_sync` - Set to false to disable the sync process.
 

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -99,12 +99,11 @@ module "ecsservice" {
 resource "cloudflare_record" "idsyncdns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id         = data.cloudflare_zone.domain.id
-  name            = var.subdomain
-  value           = var.alb_dns_name
-  type            = "CNAME"
-  proxied         = true
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.subdomain
+  value   = var.alb_dns_name
+  type    = "CNAME"
+  proxied = true
 }
 
 data "cloudflare_zone" "domain" {

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -147,9 +147,3 @@ variable "create_dns_record" {
   type        = bool
   default     = true
 }
-
-variable "dns_allow_overwrite" {
-  description = "Controls whether this module can overwrite an existing DNS record with the same name. Should be set true in a multiregion IdP."
-  type        = bool
-  default     = false
-}


### PR DESCRIPTION
### Removed
- Remove `dns_allow_overwrite` variable because it caused more significant problems than it solved. Specifically, it became confusing when running plans on primary/secondary workspaces with both being able to update the same DNS record.

### Fixed
- Corrections to README files for earlier changes