### PR TITLE
remove create_dns_record inputs

### DIFF
--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -131,8 +131,6 @@ module "ecsservice_cron" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "emaildns" {
-  count = var.create_dns_record ? 1 : 0
-
   zone_id = data.cloudflare_zone.domain.id
   name    = var.subdomain
   value   = var.internal_alb_dns_name

--- a/terraform/031-email-service/outputs.tf
+++ b/terraform/031-email-service/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value = "${var.subdomain}.${var.cloudflare_domain}"
+  value = cloudflare_record.emaildns.hostname
 }
 
 output "db_emailservice_user" {

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -143,9 +143,3 @@ variable "wildcard_cert_arn" {
 variable "enable_cron" {
   default = true
 }
-
-variable "create_dns_record" {
-  description = "Controls creation of a DNS CNAME record for the ECS service."
-  type        = bool
-  default     = true
-}

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -397,8 +397,6 @@ resource "aws_cloudwatch_event_target" "broker_event_target" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "brokerdns" {
-  count = var.create_dns_record ? 1 : 0
-
   zone_id = data.cloudflare_zone.domain.id
   name    = var.subdomain
   value   = var.internal_alb_dns_name

--- a/terraform/040-id-broker/outputs.tf
+++ b/terraform/040-id-broker/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value = "${var.subdomain}.${var.cloudflare_domain}"
+  value = cloudflare_record.brokerdns.hostname
 }
 
 output "db_idbroker_user" {

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -571,9 +571,3 @@ variable "vpc_id" {
 variable "wildcard_cert_arn" {
   type = string
 }
-
-variable "create_dns_record" {
-  description = "Controls creation of a DNS CNAME record for the ECS service."
-  type        = bool
-  default     = true
-}

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -119,8 +119,6 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "apidns" {
-  count = var.create_dns_record ? 1 : 0
-
   zone_id = data.cloudflare_zone.domain.id
   name    = var.api_subdomain
   value   = var.alb_dns_name

--- a/terraform/050-pw-manager/outputs.tf
+++ b/terraform/050-pw-manager/outputs.tf
@@ -11,7 +11,7 @@ output "ui_hostname" {
 }
 
 output "api_hostname" {
-  value = "${var.api_subdomain}.${var.cloudflare_domain}"
+  value = cloudflare_record.apidns.hostname
 }
 
 output "db_pwmanager_user" {

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -263,9 +263,3 @@ variable "vpc_id" {
 variable "wildcard_cert_arn" {
   type = string
 }
-
-variable "create_dns_record" {
-  description = "Controls creation of a DNS CNAME record for the ECS service."
-  type        = bool
-  default     = true
-}

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -117,8 +117,6 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "sspdns" {
-  count = var.create_dns_record ? 1 : 0
-
   zone_id = data.cloudflare_zone.domain.id
   name    = var.subdomain
   value   = var.alb_dns_name

--- a/terraform/060-simplesamlphp/outputs.tf
+++ b/terraform/060-simplesamlphp/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value = "${var.subdomain}.${var.cloudflare_domain}"
+  value = cloudflare_record.sspdns.hostname
 }
 
 output "db_ssp_user" {

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -194,9 +194,3 @@ variable "admin_name" {
 variable "trust_cloudflare_ips" {
   default = ""
 }
-
-variable "create_dns_record" {
-  description = "Controls creation of a DNS CNAME record for the ECS service."
-  type        = bool
-  default     = true
-}

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -97,8 +97,6 @@ module "ecsservice" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "idsyncdns" {
-  count = var.create_dns_record ? 1 : 0
-
   zone_id = data.cloudflare_zone.domain.id
   name    = var.subdomain
   value   = var.alb_dns_name

--- a/terraform/070-id-sync/outputs.tf
+++ b/terraform/070-id-sync/outputs.tf
@@ -1,5 +1,5 @@
 output "idsync_url" {
-  value = "${var.subdomain}.${var.cloudflare_domain}"
+  value = cloudflare_record.idsyncdns.hostname
 }
 
 output "access_token_external" {

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -141,9 +141,3 @@ variable "enable_new_user_notification" {
 variable "enable_sync" {
   default = true
 }
-
-variable "create_dns_record" {
-  description = "Controls creation of a DNS CNAME record for the ECS service."
-  type        = bool
-  default     = true
-}

--- a/test/031-email-service.tf
+++ b/test/031-email-service.tf
@@ -8,7 +8,6 @@ module "email" {
   cloudwatch_log_group_name = ""
   cpu_api                   = ""
   cpu_cron                  = ""
-  create_dns_record         = true
   db_name                   = ""
   desired_count_api         = ""
   docker_image              = ""

--- a/test/040-id-broker.tf
+++ b/test/040-id-broker.tf
@@ -12,7 +12,6 @@ module "broker" {
   contingent_user_duration                   = ""
   cpu                                        = ""
   cpu_cron                                   = ""
-  create_dns_record                          = true
   db_name                                    = ""
   desired_count                              = ""
   docker_image                               = ""

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -22,7 +22,6 @@ module "pw" {
   cloudwatch_log_group_name           = ""
   code_length                         = ""
   cpu                                 = ""
-  create_dns_record                   = true
   db_name                             = ""
   desired_count                       = ""
   docker_image                        = ""

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -12,7 +12,6 @@ module "ssp" {
   cloudflare_domain            = ""
   cloudwatch_log_group_name    = ""
   cpu                          = ""
-  create_dns_record            = true
   db_name                      = ""
   delete_remember_me_on_logout = ""
   desired_count                = ""

--- a/test/070-id-sync.tf
+++ b/test/070-id-sync.tf
@@ -11,7 +11,6 @@ module "sync" {
   cloudflare_domain            = ""
   cloudwatch_log_group_name    = ""
   cpu                          = ""
-  create_dns_record            = true
   docker_image                 = ""
   ecsServiceRole_arn           = ""
   ecs_cluster_id               = ""


### PR DESCRIPTION
### Removed
- Remove `create_dns_record` inputs.

_Note: this may have to wait until all services have intermediate CNAME records. Also, the `create_dns_record` input could be kept if we think it may have another use._