### PR TITLE
new variable: create_dashboard

### DIFF
--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -101,6 +101,8 @@ resource "aws_cloudwatch_log_group" "logs" {
  * Create CloudWatch Dashboard for services that will be in this cluster
  */
 module "ecs-service-cloudwatch-dashboard" {
+  count = var.create_dashboard ? 1 : 0
+
   source  = "silinternational/ecs-service-cloudwatch-dashboard/aws"
   version = "~> 3.0.1"
 

--- a/terraform/010-cluster/vars.tf
+++ b/terraform/010-cluster/vars.tf
@@ -21,6 +21,12 @@ variable "cert_domain_name" {
   type = string
 }
 
+variable "create_dashboard" {
+  description = "Set to false to remove the Cloudwatch Dashboard"
+  type        = bool
+  default     = true
+}
+
 variable "create_nat_gateway" {
   description = "Set to false to remove NAT gateway and associated route"
   type        = bool


### PR DESCRIPTION
### Added
- Added a new variable, `create_dashboard`, to control creation and management of the Cloudwatch Dashboard.