### PR TITLE
Optionally create both DNS records for email (and same for broker): with and without region

### DIFF
--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -136,7 +136,8 @@ variable "ssl_policy" {
 }
 
 variable "subdomain" {
-  type = string
+  description = "The subdomain for email-service, without an embedded region in it (e.g. 'email', NOT 'email-us-east-1')"
+  type        = string
 }
 
 variable "vpc_id" {

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -457,7 +457,8 @@ variable "ssl_policy" {
 }
 
 variable "subdomain" {
-  type = string
+  description = "The subdomain for id-broker, without an embedded region in it (e.g. 'broker', NOT 'broker-us-east-1')"
+  type        = string
 }
 
 variable "subject_for_abandoned_users" {


### PR DESCRIPTION
### Fixed
- Have broker create both dns records (with and without region)
  * This avoids downtime during an upgrade, because the other containers
(ssp, pw-api, sync) will still be able to reach this container using the
old (non-region) domain name. After we finish the upgrade, everything
will be using the region-specific domain name, and the non-region DNS
record can be removed.
- Have email-service create both dns records (with and without region)
  * (same benefit as above, for broker)
- Clarify that "subdomain" vars should not include the region