### PR TITLE
Fix `replicate_source_db` to default to `null`, which we check for

### DIFF
--- a/terraform/020-database/vars.tf
+++ b/terraform/020-database/vars.tf
@@ -79,5 +79,5 @@ variable "create_passwords" {
 variable "replicate_source_db" {
   type        = string
   description = "To create a replica DB in a separate region, specify the source database ARN"
-  default     = ""
+  default     = null
 }


### PR DESCRIPTION
### Fixed
- Fix `replicate_source_db` to default to `null`, which we check for within the terraform module to know whether it has a meaningful value or not.