### PR TITLE
remove ECR repos for email-service and db-backup

### DIFF
--- a/terraform/022-ecr/README.md
+++ b/terraform/022-ecr/README.md
@@ -1,9 +1,9 @@
 # 022-ecr - EC2 Container Service Image Repository
-This module is used to create an ECS image repositories for all services
+This module is used to create ECR image repositories for ECS services
 
 ## What this does
 
- - Create ECR repositories for id-broker, email-service, pw-manager, simplesamlphp, and id-sync
+ - Create ECR repositories for id-broker, pw-manager, simplesamlphp, and id-sync
  - Attach ECR policy to allow appropriate access
 
 ## Required Inputs
@@ -16,7 +16,6 @@ This module is used to create an ECS image repositories for all services
 ## Outputs
 
  - `ecr_repo_idbroker` - The repository url for id-broker. Ex: `1234567890.dkr.ecr.us-east-1.amazonaws.com/idp-name/id-broker-environment`
- - `ecr_repo_emailservice` - The repository url for email-service. Ex: `1234567890.dkr.ecr.us-east-1.amazonaws.com/idp-name/email-service-environment`
  - `ecr_repo_pwapi` - The repository url for pw-api. Ex: `1234567890.dkr.ecr.us-east-1.amazonaws.com/idp-name/pw-api-environment`
  - `ecr_repo_simplesamlphp` - The repository url for simplesamlphp. Ex: `1234567890.dkr.ecr.us-east-1.amazonaws.com/idp-name/simplesamlphp-environment`
  - `ecr_repo_idsync` - The repository url for id-sync. Ex: `1234567890.dkr.ecr.us-east-1.amazonaws.com/idp-name/id-sync-environment`

--- a/terraform/022-ecr/main.tf
+++ b/terraform/022-ecr/main.tf
@@ -12,19 +12,6 @@ module "ecr_idbroker" {
 }
 
 /*
- * email-service
- */
-module "ecr_emailservice" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.6.0"
-  repo_name             = "${var.idp_name}/email-service"
-  ecsInstanceRole_arn   = var.ecsInstanceRole_arn
-  ecsServiceRole_arn    = var.ecsServiceRole_arn
-  cd_user_arn           = var.cd_user_arn
-  image_retention_count = 10
-  image_retention_tags  = ["latest"]
-}
-
-/*
  * pw-api
  */
 module "ecr_pwapi" {
@@ -62,17 +49,3 @@ module "ecr_idsync" {
   image_retention_count = 10
   image_retention_tags  = ["latest"]
 }
-
-/*
- * db-backup
- */
-module "ecr_dbbackup" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.6.0"
-  repo_name             = "${var.idp_name}/db-backup"
-  ecsInstanceRole_arn   = var.ecsInstanceRole_arn
-  ecsServiceRole_arn    = var.ecsServiceRole_arn
-  cd_user_arn           = var.cd_user_arn
-  image_retention_count = 10
-  image_retention_tags  = ["latest"]
-}
-

--- a/terraform/022-ecr/outputs.tf
+++ b/terraform/022-ecr/outputs.tf
@@ -2,10 +2,6 @@ output "ecr_repo_idbroker" {
   value = module.ecr_idbroker.repo_url
 }
 
-output "ecr_repo_emailservice" {
-  value = module.ecr_emailservice.repo_url
-}
-
 output "ecr_repo_pwapi" {
   value = module.ecr_pwapi.repo_url
 }
@@ -17,8 +13,3 @@ output "ecr_repo_simplesamlphp" {
 output "ecr_repo_idsync" {
   value = module.ecr_idsync.repo_url
 }
-
-output "ecr_repo_dbbackup" {
-  value = module.ecr_dbbackup.repo_url
-}
-


### PR DESCRIPTION
### Removed
- Removed `email-service` and `db-backup` ECR repositories. We never add any layers to the public Docker image in these modules. They can always use the public images (`silintl/email-service` and `silintl/mysql-backup-restore`).
