### PR TITLE
db-ssp to use mariadb:10 directly

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       PMA_PASSWORD: broker
 
   db-ssp:
-    image: silintl/mariadb:latest
+    image: mariadb:10
     ports:
       - "3306"
     environment:


### PR DESCRIPTION
### Changed
- Update to direct usage of mariadb:10 image