### PR TITLE
use aws_region data source instead of the variable

### DIFF
--- a/terraform/010-cluster/README.md
+++ b/terraform/010-cluster/README.md
@@ -16,7 +16,6 @@ ssl certificate, core application load balancer, and a CloudWatch log group
  - `app_name` - Name of application, ex: Doorman, IdP, etc.
  - `app_env` - Name of environment, ex: prod, test, etc.
  - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`
- - `aws_region` - A string with region to deploy in, example: `us-east-1`
  - `aws_zones` - A list of availability zones to distribute instances across, example: `["us-east-1a", "us-east-1b", "us-east-1c"]`
  - `cert_domain_name` - Domain name for certificate, example: `*.mydomain.com`
  - `ecs_cluster_name` - ECS cluster name for registering instances
@@ -58,7 +57,6 @@ module "cluster" {
   app_name                = var.app_name
   app_env                 = var.app_env
   aws_instance            = var.aws_instance
-  aws_region              = var.aws_region
   aws_zones               = var.aws_zones
   cert_domain_name        = var.cert_domain_name
   ecs_cluster_name        = data.terraform_remote_state.core.ecs_cluster_name

--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -11,7 +11,6 @@ This module is used to create an ECS service running email-service.
 ## Required Inputs
 
  - `app_env` - Application environment
- - `aws_region` - AWS region
  - `cloudflare_domain` - Top level domain name for use with Cloudflare
  - `cloudwatch_log_group_name` - CloudWatch log group name
  - `db_name` - Name of MySQL database for email-service
@@ -64,7 +63,6 @@ module "email" {
   source                    = "github.com/silinternational/idp-in-a-box//terraform/031-email-service"
   app_env                   = var.app_env
   app_name                  = var.app_name
-  aws_region                = var.aws_region`
   cloudflare_domain         = var.cloudflare_domain
   cloudwatch_log_group_name = var.cloudwatch_log_group_name
   cpu_api                   = var.cpu_api

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -8,7 +8,9 @@ variable "app_name" {
 }
 
 variable "aws_region" {
-  type = string
+  description = "This is not used. The region is more reliably determined from the aws_region data source."
+  type        = string
+  default     = ""
 }
 
 variable "cloudflare_domain" {

--- a/terraform/031-email-service/vars.tf
+++ b/terraform/031-email-service/vars.tf
@@ -8,7 +8,7 @@ variable "app_name" {
 }
 
 variable "aws_region" {
-  description = "This is not used. The region is more reliably determined from the aws_region data source."
+  description = "WARNING: This is not used. The region is more reliably determined from the aws_region data source."
   type        = string
   default     = ""
 }

--- a/terraform/032-db-backup/README.md
+++ b/terraform/032-db-backup/README.md
@@ -10,7 +10,6 @@ This module is used to run mysqldump and backup files to S3
 ## Required Inputs
 
  - `app_env` - Application environment
- - `aws_region` - AWS region
  - `cloudwatch_log_group_name` - CloudWatch log group name
  - `docker_image` - The docker image to use for this
  - `ecs_cluster_id` - ID for ECS Cluster
@@ -44,7 +43,6 @@ module "dbbackup" {
   source                    = "github.com/silinternational/idp-in-a-box//terraform/032-db-backup"
   app_env                   = var.app_env
   app_name                  = var.app_name
-  aws_region                = var.aws_region`
   cloudwatch_log_group_name = var.cloudwatch_log_group_name
   cpu                       = var.cpu
   cron_schedule             = var.cron_schedule

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -1,3 +1,8 @@
+locals {
+  aws_account = data.aws_caller_identity.this.account_id
+  aws_region  = data.aws_region.current.name
+}
+
 /*
  * Create S3 bucket for storing backups
  */
@@ -82,7 +87,7 @@ locals {
   task_def_backup = templatefile("${path.module}/task-definition.json", {
     app_env                   = var.app_env
     app_name                  = var.app_name
-    aws_region                = var.aws_region
+    aws_region                = local.aws_region
     cloudwatch_log_group_name = var.cloudwatch_log_group_name
     aws_access_key            = aws_iam_access_key.backup.id
     aws_secret_key            = aws_iam_access_key.backup.secret
@@ -183,3 +188,10 @@ resource "aws_cloudwatch_event_target" "backup_event_target" {
   }
 }
 
+/*
+ * AWS data
+ */
+
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "current" {}

--- a/terraform/032-db-backup/vars.tf
+++ b/terraform/032-db-backup/vars.tf
@@ -8,7 +8,9 @@ variable "app_name" {
 }
 
 variable "aws_region" {
-  type = string
+  description = "This is not used. The region is more reliably determined from the aws_region data source."
+  type        = string
+  default     = ""
 }
 
 variable "backup_user_name" {

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -11,7 +11,6 @@ This module is used to create an ECS service running id-broker.
 
  - `app_env` - Application environment
  - `app_name` - Application name
- - `aws_region` - AWS region
  - `cloudflare_domain` - Top level domain name for use with Cloudflare
  - `cloudwatch_log_group_name` - CloudWatch log group name
  - `db_name` - Name of MySQL database for id-broker
@@ -145,7 +144,6 @@ module "broker" {
   source                           = "github.com/silinternational/idp-in-a-box//terraform/040-id-broker"
   app_env                          = var.app_env
   app_name                         = var.app_name
-  aws_region                       = var.aws_region
   cloudflare_domain                = var.cloudflare_domain
   cloudwatch_log_group_name        = var.cloudwatch_log_group_name
   contingent_user_duration         = var.contingent_user_duration

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -1,3 +1,8 @@
+locals {
+  aws_account = data.aws_caller_identity.this.account_id
+  aws_region  = data.aws_region.current.name
+}
+
 /*
  * Create target group for ALB
  */
@@ -71,7 +76,7 @@ locals {
     random_id.access_token_idsync.hex
   ])
 
-  subdomain_with_region = "${var.subdomain}-${var.aws_region}"
+  subdomain_with_region = "${var.subdomain}-${local.aws_region}"
 
   task_def = templatefile("${path.module}/task-definition.json", {
     api_access_keys                            = local.api_access_keys
@@ -80,7 +85,7 @@ locals {
     abandoned_user_deactivate_instructions_url = var.abandoned_user_deactivate_instructions_url
     app_env                                    = var.app_env
     app_name                                   = var.app_name
-    aws_region                                 = var.aws_region
+    aws_region                                 = local.aws_region
     cloudwatch_log_group_name                  = var.cloudwatch_log_group_name
     contingent_user_duration                   = var.contingent_user_duration
     cpu                                        = var.cpu
@@ -210,7 +215,7 @@ locals {
     abandoned_user_deactivate_instructions_url = var.abandoned_user_deactivate_instructions_url
     app_env                                    = var.app_env
     app_name                                   = var.app_name
-    aws_region                                 = var.aws_region
+    aws_region                                 = local.aws_region
     cloudwatch_log_group_name                  = var.cloudwatch_log_group_name
     cpu                                        = var.cpu_cron
     contingent_user_duration                   = var.contingent_user_duration
@@ -320,7 +325,7 @@ locals {
  * Create role for scheduled running of cron task definitions.
  */
 resource "aws_iam_role" "ecs_events" {
-  name = "ecs_events-${var.idp_name}-${var.app_name}-${var.app_env}-${var.aws_region}"
+  name = "ecs_events-${var.idp_name}-${var.app_name}-${var.app_env}-${local.aws_region}"
 
   assume_role_policy = jsonencode(
     {
@@ -414,3 +419,12 @@ resource "cloudflare_record" "brokerdns" {
 data "cloudflare_zone" "domain" {
   name = var.cloudflare_domain
 }
+
+
+/*
+ * AWS data
+ */
+
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "current" {}

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -25,7 +25,9 @@ variable "app_name" {
 }
 
 variable "aws_region" {
-  type = string
+  description = "This is deprecated. The region is more reliably determined from the aws_region data source."
+  type        = string
+  default     = ""
 }
 
 variable "cloudflare_domain" {

--- a/terraform/050-pw-manager/README.md
+++ b/terraform/050-pw-manager/README.md
@@ -25,7 +25,6 @@ The password manager UI can be deployed using the [silinternatonal/pages/cloudfl
  - `auth_saml_spCertificate` - Public cert contents for this SP
  - `auth_saml_spPrivateKey` - Private cert contents for this SP
  - `auth_saml_ssoUrl` - SSO url for IdP
- - `aws_region` - AWS region
  - `cloudflare_domain` - Top level domain name for use with Cloudflare
  - `cloudwatch_log_group_name` - CloudWatch log group name
  - `cpu` - Amount of CPU to allocate to API container
@@ -98,7 +97,6 @@ module "pwmanager" {
   auth_saml_spPrivateKey              = var.auth_saml_spPrivateKey
   auth_saml_ssoUrl                    = var.auth_saml_ssoUrl
   cd_user_username                    = data.terraform_remote_state.core.cduser_username
-  aws_region                          = var.aws_region
   cloudflare_domain                   = var.cloudflare_domain
   cloudwatch_log_group_name           = var.cloudwatch_log_group_name
   code_length                         = var.code_length

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -1,5 +1,6 @@
-
 locals {
+  aws_account = data.aws_caller_identity.this.account_id
+  aws_region  = data.aws_region.current.name
   ui_hostname = "${var.ui_subdomain}.${var.cloudflare_domain}"
 }
 
@@ -56,7 +57,7 @@ resource "random_id" "access_token_hash" {
  * Create ECS service for API
  */
 locals {
-  api_subdomain_with_region = "${var.api_subdomain}-${var.aws_region}"
+  api_subdomain_with_region = "${var.api_subdomain}-${local.aws_region}"
 
   task_def = templatefile("${path.module}/task-definition-api.json", {
     access_token_hash                   = random_id.access_token_hash.hex
@@ -64,7 +65,7 @@ locals {
     alerts_email_enabled                = var.alerts_email_enabled
     app_env                             = var.app_env
     app_name                            = var.app_name
-    aws_region                          = var.aws_region
+    aws_region                          = local.aws_region
     cloudwatch_log_group_name           = var.cloudwatch_log_group_name
     auth_saml_checkResponseSigning      = var.auth_saml_checkResponseSigning
     auth_saml_entityId                  = var.auth_saml_entityId
@@ -152,3 +153,10 @@ data "cloudflare_zone" "domain" {
   name = var.cloudflare_domain
 }
 
+/*
+ * AWS data
+ */
+
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "current" {}

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -77,7 +77,9 @@ variable "auth_saml_ssoUrl" {
 }
 
 variable "aws_region" {
-  type = string
+  description = "This is not used. The region is more reliably determined from the aws_region data source."
+  type        = string
+  default     = ""
 }
 
 variable "cd_user_username" {

--- a/terraform/060-simplesamlphp/README.md
+++ b/terraform/060-simplesamlphp/README.md
@@ -14,7 +14,6 @@ This module is used to create an ECS service running simpleSAMLphp.
  - `vpc_id` - ID for VPC
  - `alb_https_listener_arn` - ARN for ALB HTTPS listener
  - `subdomain` - Subdomain for SSP IdP
- - `aws_region` - AWS region
  - `broker_subdomain` - Subdomain for id-broker
  - `cloudflare_domain` - Top level domain name for use with Cloudflare
  - `cloudwatch_log_group_name` - CloudWatch log group name
@@ -78,7 +77,6 @@ module "ssp" {
   vpc_id                       = data.terraform_remote_state.cluster.vpc_id
   alb_https_listener_arn       = data.terraform_remote_state.cluster.alb_https_listener_arn
   subdomain                    = var.ssp_subdomain
-  aws_region                   = var.aws_region`
   cloudflare_domain            = var.cloudflare_domain
   cloudwatch_log_group_name    = var.cloudwatch_log_group_name
   docker_image                 = data.terraform_remote_state.ecr.ecr_repo_simplesamlphp

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -1,3 +1,8 @@
+locals {
+  aws_account = data.aws_caller_identity.this.account_id
+  aws_region  = data.aws_region.current.name
+}
+
 /*
  * Create target group for ALB
  */
@@ -52,7 +57,7 @@ module "cf_ips" {
 }
 
 locals {
-  subdomain_with_region = "${var.subdomain}-${var.aws_region}"
+  subdomain_with_region = "${var.subdomain}-${local.aws_region}"
 
   other_ip_addresses = var.trust_cloudflare_ips == "ipv4" ? module.cf_ips.ipv4_cidrs : []
 
@@ -68,7 +73,7 @@ locals {
     admin_pass                   = random_id.admin_pass.hex
     app_env                      = var.app_env
     app_name                     = var.app_name
-    aws_region                   = var.aws_region
+    aws_region                   = local.aws_region
     base_url                     = "https://${var.subdomain}.${var.cloudflare_domain}/"
     cloudwatch_log_group_name    = var.cloudwatch_log_group_name
     docker_image                 = var.docker_image
@@ -142,3 +147,11 @@ resource "cloudflare_record" "sspdns_intermediate" {
 data "cloudflare_zone" "domain" {
   name = var.cloudflare_domain
 }
+
+/*
+ * AWS data
+ */
+
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "current" {}

--- a/terraform/060-simplesamlphp/vars.tf
+++ b/terraform/060-simplesamlphp/vars.tf
@@ -29,7 +29,9 @@ variable "alb_https_listener_arn" {
 }
 
 variable "aws_region" {
-  type = string
+  description = "This is not used. The region is more reliably determined from the aws_region data source."
+  type        = string
+  default     = ""
 }
 
 variable "subdomain" {

--- a/terraform/070-id-sync/README.md
+++ b/terraform/070-id-sync/README.md
@@ -10,7 +10,6 @@ store.
 
  - `app_name` - Application name
  - `app_env` - Application environment
- - `aws_region` - AWS region
  - `cloudwatch_log_group_name` - CloudWatch log group name
  - `vpc_id` - ID for VPC
  - `docker_image` - URL to Docker image
@@ -54,7 +53,6 @@ module "idsync" {
   app_env                     = var.app_env
   vpc_id                      = data.terraform_remote_state.cluster.vpc_id
   alb_https_listener_arn      = data.terraform_remote_state.cluster.alb_https_listener_arn
-  aws_region                  = var.aws_region
   cloudwatch_log_group_name   = var.cloudwatch_log_group_name
   docker_image                = data.terraform_remote_state.ecr.ecr_repo_idsync
   email_service_accessToken   = data.terraform_remote_state.email.access_token_idsync

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -1,7 +1,10 @@
-/*
- * Create ECS service
- */
 locals {
+  aws_account = data.aws_caller_identity.this.account_id
+  aws_region  = data.aws_region.current.name
+
+  /*
+   * Create ECS service
+   */
   id_store_config = join(",",
     [for k, v in var.id_store_config : jsonencode({
       name  = "ID_STORE_CONFIG_${k}"
@@ -12,7 +15,7 @@ locals {
   task_def = templatefile("${path.module}/task-definition.json", {
     app_env                      = var.app_env
     app_name                     = var.app_name
-    aws_region                   = var.aws_region
+    aws_region                   = local.aws_region
     cloudwatch_log_group_name    = var.cloudwatch_log_group_name
     docker_image                 = var.docker_image
     email_service_accessToken    = var.email_service_accessToken
@@ -43,7 +46,7 @@ locals {
  * Create role for scheduled running of cron task definitions.
  */
 resource "aws_iam_role" "ecs_events" {
-  name = "ecs_events-${var.idp_name}-${var.app_name}-${var.app_env}-${var.aws_region}"
+  name = "ecs_events-${var.idp_name}-${var.app_name}-${var.app_env}-${local.aws_region}"
 
   assume_role_policy = jsonencode(
     {
@@ -123,3 +126,11 @@ resource "aws_cloudwatch_event_target" "id_sync_event_target" {
     task_definition_arn = aws_ecs_task_definition.cron_td.arn
   }
 }
+
+/*
+ * AWS data
+ */
+
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "current" {}

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -20,7 +20,9 @@ variable "vpc_id" {
 }
 
 variable "aws_region" {
-  type = string
+  description = "This is not used. The region is more reliably determined from the aws_region data source."
+  type        = string
+  default     = ""
 }
 
 variable "cloudwatch_log_group_name" {

--- a/test/031-email-service.tf
+++ b/test/031-email-service.tf
@@ -3,7 +3,6 @@ module "email" {
 
   app_env                   = ""
   app_name                  = ""
-  aws_region                = ""
   cloudflare_domain         = ""
   cloudwatch_log_group_name = ""
   cpu_api                   = ""

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -3,7 +3,6 @@ module "backup" {
 
   app_env                   = ""
   app_name                  = ""
-  aws_region                = ""
   backup_user_name          = ""
   cloudwatch_log_group_name = ""
   cpu                       = ""

--- a/test/040-id-broker.tf
+++ b/test/040-id-broker.tf
@@ -6,7 +6,6 @@ module "broker" {
   abandoned_user_deactivate_instructions_url = ""
   app_env                                    = ""
   app_name                                   = ""
-  aws_region                                 = ""
   cloudflare_domain                          = ""
   cloudwatch_log_group_name                  = ""
   contingent_user_duration                   = ""

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -16,7 +16,6 @@ module "pw" {
   auth_saml_spCertificate             = ""
   auth_saml_spPrivateKey              = ""
   auth_saml_ssoUrl                    = ""
-  aws_region                          = ""
   cd_user_username                    = ""
   cloudflare_domain                   = ""
   cloudwatch_log_group_name           = ""

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -8,7 +8,6 @@ module "ssp" {
   analytics_id                 = ""
   app_env                      = ""
   app_name                     = ""
-  aws_region                   = ""
   cloudflare_domain            = ""
   cloudwatch_log_group_name    = ""
   cpu                          = ""

--- a/test/070-id-sync.tf
+++ b/test/070-id-sync.tf
@@ -5,7 +5,6 @@ module "sync" {
   allow_empty_email            = ""
   app_env                      = ""
   app_name                     = ""
-  aws_region                   = ""
   cloudwatch_log_group_name    = ""
   cpu                          = ""
   docker_image                 = ""


### PR DESCRIPTION
### Changed
- Added a default value to `aws_region` to make it not required.
- Use the `aws_region` data source in place of the `aws_region` variable.

### Added
- Added `local` identifier `aws_region` for simplicity.
- Added `local` identifier `aws_account` for future use.