### PR TITLE
Release 12.6.1 - fix id-broker cron task

### DIFF
--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -386,6 +386,7 @@ resource "aws_ecs_task_definition" "cron_td" {
   family                = "${var.idp_name}-${var.app_name}-cron-${var.app_env}"
   container_definitions = local.task_def_cron
   network_mode          = "bridge"
+  task_role_arn         = one(module.ecs_role[*].role_arn)
 }
 
 /*


### PR DESCRIPTION
### Fixed
- Fixed id-broker cron task failing to get AppConfig data. Added the task role to the cron task definition.