### PR TITLE
Release 12.6.3 - update hashicorp/http

### DIFF
--- a/terraform/031-email-service/task-definition-api.json
+++ b/terraform/031-email-service/task-definition-api.json
@@ -26,10 +26,6 @@
         "value": "${appconfig_app_id}"
       },
       {
-        "name": "AWS_REGION",
-        "value": "${aws_region}"
-      },
-      {
         "name": "ENV_ID",
         "value": "${appconfig_env_id}"
       },

--- a/terraform/041-id-broker-search-lambda/main.tf
+++ b/terraform/041-id-broker-search-lambda/main.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
 resource "aws_lambda_function" "search" {
   s3_bucket        = var.function_bucket_name
   s3_key           = var.function_zip_name
-  source_code_hash = data.http.function-checksum.body
+  source_code_hash = data.http.function-checksum.response_body
   function_name    = "${var.function_name}-${var.idp_name}"
   handler          = var.function_name
   memory_size      = var.memory_size

--- a/terraform/041-id-broker-search-lambda/versions.tf
+++ b/terraform/041-id-broker-search-lambda/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     http = {
       source  = "hashicorp/http"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/041-id-broker-search-lambda/versions.tf
+++ b/terraform/041-id-broker-search-lambda/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     http = {
       source  = "hashicorp/http"
-      version = "~> 3.0"
+      version = ">=2.0.0, < 4.0.0"
     }
   }
 }

--- a/terraform/050-pw-manager/task-definition-api.json
+++ b/terraform/050-pw-manager/task-definition-api.json
@@ -170,7 +170,7 @@
         "value": "${password_rule_minlength}"
       },
       {
-        "name": "PASSWORD_RULE_minScore,",
+        "name": "PASSWORD_RULE_minScore",
         "value": "${password_rule_minscore}"
       },
       {

--- a/test/.terraform.lock.hcl
+++ b/test/.terraform.lock.hcl
@@ -68,21 +68,21 @@ provider "registry.terraform.io/hashicorp/http" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.5.1"
-  constraints = ">= 2.2.0, < 4.0.0"
+  version     = "3.6.2"
+  constraints = ">= 2.1.0, >= 2.2.0, < 4.0.0"
   hashes = [
-    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
   ]
 }


### PR DESCRIPTION
### Fixed
- Replace deprecated `body` attribute with `response_body` in http data source.
- Removed extraneous comma in PASSWORD_RULE_minScore variable name.
- Removed duplicated AWS_REGION variable in 031-email-service task definition.