### PR TITLE
db-backup cleanup

### DIFF
--- a/terraform/032-db-backup/README.md
+++ b/terraform/032-db-backup/README.md
@@ -25,14 +25,16 @@ This module is used to run mysqldump and backup files to S3
  - `app_name` - Application name
  - `backup_user_name` - Name of IAM user for S3 access. Default: `db-backup-${var.idp_name}-${var.app_env}`
  - `cpu` - CPU resources to allot to each task instance
- - `cron_schedule` - Schedule for CRON execution. Default: `cron(0 2 * * ? *)`
+ - `cron_schedule` - Schedule for CRON execution. DEPRECATED: use event_schedule`
+ - `event_schedule` - Schedule for backup task execution. Default: `cron(0 2 * * ? *)`
  - `db_names` - List of database names to backup. Default: `["emailservice", "idbroker", "pwmanager", "ssp"]`
  - `memory` - Memory (RAM) resources to allot to each task instance
  - `service_mode` - Either `backup` or `restore`. Default: `backup`
 
 ## Outputs
 
- - `cron_schedule` - Schedule for CRON execution
+ - `cron_schedule` - Schedule for CRON execution. DEPRECATED
+ - `event_schedule` - Schedule for CRON execution
  - `s3_bucket_name` - S3 Bucket name
  - `s3_bucket_arn` - S3 Bucket ARN
 
@@ -45,7 +47,7 @@ module "dbbackup" {
   app_name                  = var.app_name
   cloudwatch_log_group_name = var.cloudwatch_log_group_name
   cpu                       = var.cpu
-  cron_schedule             = var.cron_schedule
+  event_schedule            = var.event_schedule
   db_names                  = var.db_names
   docker_image              = data.terraform_remote_state.ecr.ecr_repo_dbbackup
   ecs_cluster_id            = data.terraform_remote_state.core.ecs_cluster_id

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -156,6 +156,10 @@ resource "aws_ecs_task_definition" "cron_td" {
   network_mode          = "bridge"
 }
 
+locals {
+  event_schedule = var.cron_schedule != "" ? var.cron_schedule : var.event_schedule
+}
+
 /*
  * CloudWatch configuration to start scheduled backup.
  */
@@ -163,7 +167,7 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
   name        = "${var.idp_name}-${var.app_name}-${var.app_env}"
   description = "Start scheduled backup"
 
-  schedule_expression = var.cron_schedule
+  schedule_expression = local.event_schedule
 
   tags = {
     app_name = var.app_name

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -85,6 +85,8 @@ resource "aws_iam_user_policy" "backup" {
  */
 locals {
   task_def_backup = templatefile("${path.module}/task-definition.json", {
+    app_env                   = var.app_env
+    app_name                  = var.app_name
     aws_region                = local.aws_region
     cloudwatch_log_group_name = var.cloudwatch_log_group_name
     aws_access_key            = aws_iam_access_key.backup.id

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -85,17 +85,13 @@ resource "aws_iam_user_policy" "backup" {
  */
 locals {
   task_def_backup = templatefile("${path.module}/task-definition.json", {
-    app_env                   = var.app_env
-    app_name                  = var.app_name
     aws_region                = local.aws_region
     cloudwatch_log_group_name = var.cloudwatch_log_group_name
     aws_access_key            = aws_iam_access_key.backup.id
     aws_secret_key            = aws_iam_access_key.backup.secret
     cpu                       = var.cpu
-    cron_schedule             = var.cron_schedule
     db_names                  = join(" ", var.db_names)
     docker_image              = var.docker_image
-    idp_name                  = var.idp_name
     mysql_host                = var.mysql_host
     mysql_pass                = var.mysql_pass
     mysql_user                = var.mysql_user

--- a/terraform/032-db-backup/outputs.tf
+++ b/terraform/032-db-backup/outputs.tf
@@ -9,4 +9,3 @@ output "s3_bucket_name" {
 output "s3_bucket_arn" {
   value = aws_s3_bucket.backup.arn
 }
-

--- a/terraform/032-db-backup/outputs.tf
+++ b/terraform/032-db-backup/outputs.tf
@@ -1,5 +1,9 @@
 output "cron_schedule" {
-  value = var.cron_schedule
+  value = local.event_schedule
+}
+
+output "event_schedule" {
+  value = local.event_schedule
 }
 
 output "s3_bucket_name" {

--- a/terraform/032-db-backup/task-definition.json
+++ b/terraform/032-db-backup/task-definition.json
@@ -60,7 +60,7 @@
       "options": {
         "awslogs-group": "${cloudwatch_log_group_name}",
         "awslogs-region": "${aws_region}",
-        "awslogs-stream-prefix": "${var.app_name}-${var.app_env}"
+        "awslogs-stream-prefix": "${app_name}-${app_env}"
       }
     },
     "cpu": ${cpu},

--- a/terraform/032-db-backup/task-definition.json
+++ b/terraform/032-db-backup/task-definition.json
@@ -60,7 +60,7 @@
       "options": {
         "awslogs-group": "${cloudwatch_log_group_name}",
         "awslogs-region": "${aws_region}",
-        "awslogs-stream-prefix": "${app_name}-${app_env}"
+        "awslogs-stream-prefix": "${var.app_name}-${var.app_env}"
       }
     },
     "cpu": ${cpu},

--- a/terraform/032-db-backup/task-definition.json
+++ b/terraform/032-db-backup/task-definition.json
@@ -16,14 +16,6 @@
     "dockerSecurityOptions": null,
     "environment": [
       {
-        "name": "APP_ENV",
-        "value": "${app_env}"
-      },
-      {
-        "name": "APP_NAME",
-        "value": "${app_name}"
-      },
-      {
         "name": "AWS_ACCESS_KEY",
         "value": "${aws_access_key}"
       },
@@ -32,16 +24,8 @@
         "value": "${aws_secret_key}"
       },
       {
-        "name": "CRON_SCHEDULE",
-        "value": "${cron_schedule}"
-      },
-      {
         "name": "DB_NAMES",
         "value": "${db_names}"
-      },
-      {
-        "name": "IDP_NAME",
-        "value": "${idp_name}"
       },
       {
         "name": "MODE",

--- a/terraform/032-db-backup/vars.tf
+++ b/terraform/032-db-backup/vars.tf
@@ -84,4 +84,3 @@ variable "service_mode" {
 variable "vpc_id" {
   type = string
 }
-

--- a/terraform/032-db-backup/vars.tf
+++ b/terraform/032-db-backup/vars.tf
@@ -28,8 +28,9 @@ variable "cpu" {
 }
 
 variable "cron_schedule" {
-  type    = string
-  default = "cron(0 2 * * ? *)"
+  description = "Schedule for CRON execution. DEPRECATED: use event_schedule"
+  type        = string
+  default     = ""
 }
 
 variable "db_names" {
@@ -53,6 +54,12 @@ variable "ecs_cluster_id" {
 
 variable "ecsServiceRole_arn" {
   type = string
+}
+
+variable "event_schedule" {
+  description = "Schedule for backup task execution. Default: `cron(0 2 * * ? *)"
+  type        = string
+  default     = "cron(0 2 * * ? *)"
 }
 
 variable "idp_name" {

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -6,7 +6,7 @@ module "backup" {
   backup_user_name          = ""
   cloudwatch_log_group_name = ""
   cpu                       = ""
-  cron_schedule             = ""
+  event_schedule            = ""
   db_names                  = [""]
   docker_image              = ""
   ecsServiceRole_arn        = ""


### PR DESCRIPTION
### Added
- New input and output `event_schedule` to replace `cron_schedule`.

### Changed (non-breaking)
- Removed unused ([reference](https://github.com/silinternational/mysql-backup-restore)) environment variables from db-backup task definition. Prior to this change, when `cron_schedule` changed, it forced an unnecessary change in the task definition. 
- Deprecated `cron_schedule` and recommend use of `event_schedule` instead. Changing for consistency and clarity. A "cron-type" schedule is only one of two types of event schedules.