### PR TITLE
Release 12.8.3 -- add AWS region to dashboard name

### DIFF
--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -114,7 +114,7 @@ module "ecs-service-cloudwatch-dashboard" {
   version = "~> 3.0.1"
 
   cluster_name   = var.ecs_cluster_name
-  dashboard_name = "${var.app_name}-${var.app_env}"
+  dashboard_name = "${var.app_name}-${var.app_env}-${data.aws_region.current.name}"
 
   service_names = [
     "${var.idp_name}-db-backup",
@@ -129,3 +129,4 @@ module "ecs-service-cloudwatch-dashboard" {
   ]
 }
 
+data "aws_region" "current" {}


### PR DESCRIPTION

### Fixed
- Add AWS region to the Cloudwatch Dashboard name to keep primary and secondary regions from overwriting the dashboard.
