### PR TITLE
Release 12.9.3 -- rename cloudflare security group

### DIFF
--- a/terraform/000-core/main.tf
+++ b/terraform/000-core/main.tf
@@ -2,7 +2,7 @@
  * Create ECS cluster
  */
 module "ecscluster" {
-  source       = "github.com/silinternational/terraform-modules//aws/ecs/cluster?ref=8.13.1"
+  source       = "github.com/silinternational/terraform-modules//aws/ecs/cluster?ref=8.13.2"
   cluster_name = var.cluster_name
 }
 

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -22,7 +22,7 @@ module "vpc" {
  * Security group to limit traffic to Cloudflare IPs
  */
 module "cloudflare-sg" {
-  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=8.13.1"
+  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=8.13.2"
   vpc_id = module.vpc.id
 }
 
@@ -43,7 +43,7 @@ data "aws_ami" "ecs_ami" {
  * Create auto-scaling group
  */
 module "asg" {
-  source                  = "github.com/silinternational/terraform-modules//aws/asg?ref=8.13.1"
+  source                  = "github.com/silinternational/terraform-modules//aws/asg?ref=8.13.2"
   app_name                = var.app_name
   app_env                 = var.app_env
   aws_instance            = var.aws_instance

--- a/terraform/020-database/main.tf
+++ b/terraform/020-database/main.tf
@@ -8,7 +8,7 @@ resource "random_id" "db_root_pass" {
 }
 
 module "rds" {
-  source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=8.13.1"
+  source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=8.13.2"
   app_name                = var.app_name
   app_env                 = var.app_env
   db_name                 = var.db_name

--- a/terraform/022-ecr/main.tf
+++ b/terraform/022-ecr/main.tf
@@ -2,7 +2,7 @@
  * id-broker
  */
 module "ecr_idbroker" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.1"
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.2"
   repo_name             = "${var.idp_name}/id-broker"
   ecsInstanceRole_arn   = var.ecsInstanceRole_arn
   ecsServiceRole_arn    = var.ecsServiceRole_arn
@@ -15,7 +15,7 @@ module "ecr_idbroker" {
  * pw-api
  */
 module "ecr_pwapi" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.1"
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.2"
   repo_name             = "${var.idp_name}/pw-api"
   ecsInstanceRole_arn   = var.ecsInstanceRole_arn
   ecsServiceRole_arn    = var.ecsServiceRole_arn
@@ -28,7 +28,7 @@ module "ecr_pwapi" {
  * simplesamlphp
  */
 module "ecr_simplesamlphp" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.1"
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.2"
   repo_name             = "${var.idp_name}/simplesamlphp"
   ecsInstanceRole_arn   = var.ecsInstanceRole_arn
   ecsServiceRole_arn    = var.ecsServiceRole_arn
@@ -41,7 +41,7 @@ module "ecr_simplesamlphp" {
  * id-sync
  */
 module "ecr_idsync" {
-  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.1"
+  source                = "github.com/silinternational/terraform-modules//aws/ecr?ref=8.13.2"
   repo_name             = "${var.idp_name}/id-sync"
   ecsInstanceRole_arn   = var.ecsInstanceRole_arn
   ecsServiceRole_arn    = var.ecsServiceRole_arn

--- a/terraform/031-email-service/main.tf
+++ b/terraform/031-email-service/main.tf
@@ -143,7 +143,7 @@ locals {
 }
 
 module "ecsservice_api" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-api"
   service_env        = var.app_env
@@ -188,7 +188,7 @@ locals {
 }
 
 module "ecsservice_cron" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-no-alb?ref=8.13.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-no-alb?ref=8.13.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-cron"
   service_env        = var.app_env

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -199,7 +199,7 @@ locals {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -121,7 +121,7 @@ locals {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env

--- a/terraform/060-simplesamlphp/main.tf
+++ b/terraform/060-simplesamlphp/main.tf
@@ -55,7 +55,7 @@ resource "random_id" "secretsalt" {
 }
 
 module "cf_ips" {
-  source = "github.com/silinternational/terraform-modules//cloudflare/ips?ref=8.13.1"
+  source = "github.com/silinternational/terraform-modules//cloudflare/ips?ref=8.13.2"
 }
 
 locals {
@@ -116,7 +116,7 @@ locals {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.2"
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
   service_env        = var.app_env


### PR DESCRIPTION
### Changed
- Update terraform-modules to rename cloudflare security group to remove ipv4, since it has ipv6 subnets now.
