### PR TITLE
update scheduled-ecs-task to fix role name length issue

### DIFF
--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -115,7 +115,7 @@ locals {
 
 module "backup_task" {
   source  = "silinternational/scheduled-ecs-task/aws"
-  version = "0.1.0"
+  version = "~> 0.1"
 
   name                   = "${var.idp_name}-${var.app_name}-${var.app_env}"
   event_rule_description = "Start scheduled backup"

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -214,7 +214,7 @@ module "ecsservice" {
 
 module "cron_task" {
   source  = "silinternational/scheduled-ecs-task/aws"
-  version = "0.1.0"
+  version = "~> 0.1"
 
   name                   = "${var.idp_name}-${var.app_name}-cron-${var.app_env}-${local.aws_region}"
   event_rule_description = "Start broker scheduled tasks"

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -51,7 +51,7 @@ locals {
 
 module "cron_task" {
   source  = "silinternational/scheduled-ecs-task/aws"
-  version = "0.1.0"
+  version = "~> 0.1"
 
   name                   = "${var.idp_name}-${var.app_name}-cron-${var.app_env}-${local.aws_region}"
   event_rule_description = "Start ID Sync scheduled tasks"


### PR DESCRIPTION

### Changed
- Update scheduled-task module to change the aws_iam_role name prefix. At least one IdP exceeded the max length of 64.
