### PR TITLE
Release 12.11.1 -- add check on cloudflare_domain to avoid plan fail

### DIFF
--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_log_group" "logs" {
  * Create CloudWatch Dashboard for services that will be in this cluster
  */
 module "ecs-service-cloudwatch-dashboard" {
-  count = var.create_dashboard ? 1 : 0
+  count = var.create_dashboard && var.cloudflare_domain != "" ? 1 : 0
 
   source  = "silinternational/ecs-service-cloudwatch-dashboard/aws"
   version = "~> 3.1"


### PR DESCRIPTION

### Fixed
- Bypass creation of the cloudflare_ruleset if cloudflare_domain isn't specified.
