### PR TITLE
Release 12.11.2 -- add IdP name to WAF rule

### DIFF
--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -150,7 +150,7 @@ resource "cloudflare_ruleset" "nat" {
   rules {
     action      = "skip"
     expression  = "(ip.src eq ${module.vpc.nat_gateway_ip})"
-    description = "skip outbound NAT gateway IP address"
+    description = "${var.idp_name} NAT gateway skip bot protection"
     enabled     = true
     action_parameters {
       phases = [


### PR DESCRIPTION
### Fixed
- Try adding the IdP name to the WAF rule to avoid error message: "A similar configuration with rules already exists and overwriting will have unintended consequences."
