### PR TITLE
add configuration to control the AWS Backup lifecycle

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,3 +9,4 @@ jobs:
     uses: silinternational/workflows/.github/workflows/terraform.yml@main
     with:
       terraform-version: '~> 1.1'
+      directory: test

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,44 +1,11 @@
-# This workflow installs the latest version of Terraform CLI. On pull request events, this workflow will run
-# `terraform init`, `terraform fmt`, and `terraform plan`.
-#
-# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
-
-name: 'Terraform'
+name: Terraform
 
 on:
   push:
-  pull_request:
-
-permissions:
-  contents: read
+    branches: [ '**' ]
 
 jobs:
-  terraform:
-    name: 'Terraform'
-    runs-on: ubuntu-latest
-
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    # Install the latest version of Terraform CLI
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
-
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check -diff -recursive
-
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform -chdir=test init
-
-    # Validate the files, referring only to the configuration and not accessing any remote services
-    - name: Terraform Validate
-      run: terraform -chdir=test validate
+  build:
+    uses: silinternational/workflows/.github/workflows/terraform.yml@main
+    with:
+      terraform-version: '~> 1.1'

--- a/terraform/032-db-backup/README.md
+++ b/terraform/032-db-backup/README.md
@@ -27,6 +27,7 @@ This module is used to run mysqldump and backup files to S3
  - `cpu` - CPU resources to allot to each task instance
  - `cron_schedule` - Schedule for CRON execution. DEPRECATED: use event_schedule`
  - `event_schedule` - Schedule for backup task execution. Default: `cron(0 2 * * ? *)`
+ - `delete_recovery_point_after_days` - Number of days after which AWS Backup recovery points are deleted. Default: 100
  - `db_names` - List of database names to backup. Default: `["emailservice", "idbroker", "pwmanager", "ssp"]`
  - `memory` - Memory (RAM) resources to allot to each task instance
  - `service_mode` - Either `backup` or `restore`. Default: `backup`

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -148,7 +148,7 @@ module "aws_backup" {
   count = var.enable_aws_backup ? 1 : 0
 
   source  = "silinternational/backup/aws"
-  version = "~> 0.2.1"
+  version = "~> 0.2.2"
 
   app_name               = var.idp_name
   app_env                = var.app_env

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -148,7 +148,7 @@ module "aws_backup" {
   count = var.enable_aws_backup ? 1 : 0
 
   source  = "silinternational/backup/aws"
-  version = "~> 0.2.0"
+  version = "~> 0.2.1"
 
   app_name               = var.idp_name
   app_env                = var.app_env
@@ -157,6 +157,7 @@ module "aws_backup" {
   notification_events    = var.aws_backup_notification_events
   sns_topic_name         = "${var.idp_name}-backup-vault-events"
   sns_email_subscription = var.backup_sns_email
+  delete_after           = 4
 }
 
 data "aws_db_instance" "this" {

--- a/terraform/032-db-backup/main.tf
+++ b/terraform/032-db-backup/main.tf
@@ -157,7 +157,8 @@ module "aws_backup" {
   notification_events    = var.aws_backup_notification_events
   sns_topic_name         = "${var.idp_name}-backup-vault-events"
   sns_email_subscription = var.backup_sns_email
-  delete_after           = 4
+  cold_storage_after     = 0
+  delete_after           = var.delete_recovery_point_after_days
 }
 
 data "aws_db_instance" "this" {

--- a/terraform/032-db-backup/vars.tf
+++ b/terraform/032-db-backup/vars.tf
@@ -115,3 +115,9 @@ variable "backup_sns_email" {
   type        = string
   default     = ""
 }
+
+variable "delete_recovery_point_after_days" {
+  description = "Number of days after which AWS Backup recovery points are deleted"
+  type        = number
+  default     = 100
+}

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -20,7 +20,7 @@ module "backup" {
   vpc_id                           = ""
   enable_aws_backup                = true
   aws_backup_schedule              = ""
-  aws_backup_notification_events   = ""
+  aws_backup_notification_events   = [""]
   backup_sns_email                 = ""
   delete_recovery_point_after_days = 7
 }

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -1,21 +1,26 @@
 module "backup" {
   source = "../terraform/032-db-backup"
 
-  app_env                   = ""
-  app_name                  = ""
-  backup_user_name          = ""
-  cloudwatch_log_group_name = ""
-  cpu                       = ""
-  event_schedule            = ""
-  db_names                  = [""]
-  docker_image              = ""
-  ecsServiceRole_arn        = ""
-  ecs_cluster_id            = ""
-  idp_name                  = ""
-  memory                    = ""
-  mysql_host                = ""
-  mysql_pass                = ""
-  mysql_user                = ""
-  service_mode              = ""
-  vpc_id                    = ""
+  app_env                          = ""
+  app_name                         = ""
+  backup_user_name                 = ""
+  cloudwatch_log_group_name        = ""
+  cpu                              = ""
+  event_schedule                   = ""
+  db_names                         = [""]
+  docker_image                     = ""
+  ecsServiceRole_arn               = ""
+  ecs_cluster_id                   = ""
+  idp_name                         = ""
+  memory                           = ""
+  mysql_host                       = ""
+  mysql_pass                       = ""
+  mysql_user                       = ""
+  service_mode                     = ""
+  vpc_id                           = ""
+  enable_aws_backup                = true
+  aws_backup_schedule              = ""
+  aws_backup_notification_events   = ""
+  backup_sns_email                 = ""
+  delete_recovery_point_after_days = 7
 }


### PR DESCRIPTION
[ITSE-1591](https://itse.youtrack.cloud/issue/ITSE-1591) Remove AWS Backups where redundant

---

### Added
- Added a new variable (`delete_recovery_point_after_days`) to 032-db-backup module to set the number of days to keep AWS Backup recovery points.

### Changed
- Changed the Terraform check to run on a branch push, but not pull requests.
- Changed `cold_storage_after` to 0 because AWS Backup doesn't support cold storage for RDS backups.