### PR TITLE
remove the Cloudflare WAF rule

### DIFF
--- a/terraform/010-cluster/README.md
+++ b/terraform/010-cluster/README.md
@@ -12,7 +12,6 @@ ssl certificate, core application load balancer, and a CloudWatch log group
  - Create CloudWatch log group
  - Optionally create a Cloudwatch dashboard
  - Optionally create a NAT gateway
- - Create a Cloudflare rule to allow access to the NAT gateway (if enabled)
 
 ## Required Inputs
 

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -136,33 +136,3 @@ module "ecs-service-cloudwatch-dashboard" {
 }
 
 data "aws_region" "current" {}
-
-
-resource "cloudflare_ruleset" "nat" {
-  count = var.create_nat_gateway ? 1 : 0
-
-  zone_id     = data.cloudflare_zone.this.id
-  name        = "Bypass bot protection"
-  description = "Skip super bot fight mode to ensure id-broker can access MFA API"
-  kind        = "zone"
-  phase       = "http_request_firewall_custom"
-
-  rules {
-    action      = "skip"
-    expression  = "(ip.src eq ${module.vpc.nat_gateway_ip})"
-    description = "${var.idp_name} NAT gateway skip bot protection"
-    enabled     = true
-    action_parameters {
-      phases = [
-        "http_request_sbfm"
-      ]
-    }
-    logging {
-      enabled = true
-    }
-  }
-}
-
-data "cloudflare_zone" "this" {
-  name = var.cloudflare_domain
-}

--- a/terraform/010-cluster/versions.tf
+++ b/terraform/010-cluster/versions.tf
@@ -6,12 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0.0, < 6.0.0"
     }
-    cloudflare = {
-      source = "cloudflare/cloudflare"
-
-      // 4.39.0 deprecated cloudflare_record.value
-      // While waiting for version 5 to mature, we'll constrain to earlier versions.
-      version = ">= 2.0.0, < 4.39.0"
-    }
   }
 }

--- a/test/010-cluster.tf
+++ b/test/010-cluster.tf
@@ -6,7 +6,6 @@ module "cluster" {
   aws_instance             = { a = "b" }
   aws_zones                = [""]
   cert_domain_name         = ""
-  cloudflare_domain        = ""
   create_nat_gateway       = true
   ecs_cluster_name         = ""
   ecs_instance_profile_id  = ""


### PR DESCRIPTION
### Removed
- Removed the Cloudflare WAF rule created for the Super Bot Fight mode. Terraform failed to create multiple similar WAF rules when more than one IdP came into play. We now create this at the AWS account level.
