### PR TITLE
remove cloudflare_domain from 010-cluster

### DIFF
--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_log_group" "logs" {
  * Create CloudWatch Dashboard for services that will be in this cluster
  */
 module "ecs-service-cloudwatch-dashboard" {
-  count = var.create_dashboard && var.cloudflare_domain != "" ? 1 : 0
+  count = var.create_dashboard ? 1 : 0
 
   source  = "silinternational/ecs-service-cloudwatch-dashboard/aws"
   version = "~> 3.1"

--- a/terraform/010-cluster/vars.tf
+++ b/terraform/010-cluster/vars.tf
@@ -21,12 +21,6 @@ variable "cert_domain_name" {
   type = string
 }
 
-variable "cloudflare_domain" {
-  description = "The base domain name to be used for Cloudflare resources, e.g. example.net"
-  type        = string
-  default     = ""
-}
-
 variable "create_dashboard" {
   description = "Set to false to remove the Cloudwatch Dashboard"
   type        = bool


### PR DESCRIPTION

### Removed
- Removed `cloudflare_domain` from 010-cluster module. It is left over from the removed WAF rule.

