### PR TITLE
use one new variable (auth_saml_idp_url) for slo and sso URLs

### DIFF
--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -78,10 +78,10 @@ locals {
     auth_saml_idpCertificate            = var.auth_saml_idpCertificate
     auth_saml_requireEncryptedAssertion = var.auth_saml_requireEncryptedAssertion
     auth_saml_signRequest               = var.auth_saml_signRequest
-    auth_saml_sloUrl                    = var.auth_saml_sloUrl
+    auth_saml_sloUrl                    = coalesce(var.auth_saml_sloUrl, "${var.auth_saml_idp_url}/saml2/idp/SingleLogoutService.php")
     auth_saml_spCertificate             = var.auth_saml_spCertificate
     auth_saml_spPrivateKey              = var.auth_saml_spPrivateKey
-    auth_saml_ssoUrl                    = var.auth_saml_ssoUrl
+    auth_saml_ssoUrl                    = coalesce(var.auth_saml_ssoUrl, "${var.auth_saml_idp_url}/saml2/idp/SSOService.php")
     cmd                                 = "/data/run.sh"
     code_length                         = var.code_length
     cpu                                 = var.cpu

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -42,6 +42,12 @@ variable "auth_saml_entityId" {
   type        = string
 }
 
+variable "auth_saml_idp_url" {
+  description = "Base URL of the IdP, e.g. \"https://login.example.com\""
+  type        = string
+  default     = ""
+}
+
 variable "auth_saml_idpCertificate" {
   description = "Public cert data for IdP"
   type        = string
@@ -59,8 +65,9 @@ variable "auth_saml_signRequest" {
 }
 
 variable "auth_saml_sloUrl" {
-  description = "SLO url for IdP"
+  description = "Single logout URL for IdP. DEPRECATED: specify auth_saml_idp_url"
   type        = string
+  default     = ""
 }
 
 variable "auth_saml_spCertificate" {
@@ -74,8 +81,9 @@ variable "auth_saml_spPrivateKey" {
 }
 
 variable "auth_saml_ssoUrl" {
-  description = "SSO url for IdP"
+  description = "Single sign-on URL for IdP. DEPRECATED: specify auth_saml_idp_url"
   type        = string
+  default     = ""
 }
 
 variable "cloudflare_domain" {


### PR DESCRIPTION

### Deprecated
- Deprecate `auth_saml_sloUrl` and `auth_saml_ssoUrl`. Use new variable `auth_saml_idp_url` instead.