### PR TITLE
Release 12.14.2 -- revert addition of new MFA key/secret inputs

### DIFF
--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -137,11 +137,11 @@ locals {
     mfa_manager_help_bcc                       = var.mfa_manager_help_bcc
     mfa_required_for_new_users                 = var.mfa_required_for_new_users
     mfa_totp_apibaseurl                        = var.mfa_totp_apibaseurl
-    mfa_totp_apikey                            = coalesce(var.mfa_totp_apikey, var.mfa_api_key)
-    mfa_totp_apisecret                         = coalesce(var.mfa_totp_apisecret, var.mfa_api_secret)
+    mfa_totp_apikey                            = var.mfa_totp_apikey
+    mfa_totp_apisecret                         = var.mfa_totp_apisecret
     mfa_webauthn_apibaseurl                    = var.mfa_webauthn_apibaseurl
-    mfa_webauthn_apikey                        = coalesce(var.mfa_webauthn_apikey, var.mfa_api_key)
-    mfa_webauthn_apisecret                     = coalesce(var.mfa_webauthn_apisecret, var.mfa_api_secret)
+    mfa_webauthn_apikey                        = var.mfa_webauthn_apikey
+    mfa_webauthn_apisecret                     = var.mfa_webauthn_apisecret
     mfa_webauthn_appid                         = var.mfa_webauthn_appid
     mfa_webauthn_rpdisplayname                 = var.mfa_webauthn_rpdisplayname
     mfa_webauthn_rpid                          = coalesce(var.mfa_webauthn_rpid, var.cloudflare_domain)

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -261,18 +261,6 @@ variable "mfa_allow_disable" {
   default = "true"
 }
 
-variable "mfa_api_key" {
-  description = "API Key for TOTP and Webauthn services"
-  type        = string
-  default     = ""
-}
-
-variable "mfa_api_secret" {
-  description = "API Secret for TOTP and Webauthn services"
-  type        = string
-  default     = ""
-}
-
 variable "mfa_lifetime" {
   type    = string
   default = "+2 hours"
@@ -298,13 +286,13 @@ variable "mfa_totp_apibaseurl" {
 }
 
 variable "mfa_totp_apikey" {
-  description = "API Key for TOTP service. DEPRECATED: use mfa_api_key"
+  description = "API Key for TOTP service. DEPRECATED: use Parameter Store"
   type        = string
   default     = ""
 }
 
 variable "mfa_totp_apisecret" {
-  description = "API Key for TOTP service. DEPRECATED: use mfa_api_secret"
+  description = "API Key for TOTP service. DEPRECATED: use Parameter Store"
   type        = string
   default     = ""
 }
@@ -314,13 +302,13 @@ variable "mfa_webauthn_apibaseurl" {
 }
 
 variable "mfa_webauthn_apikey" {
-  description = "API Key for Webauthn service. DEPRECATED: use mfa_api_key"
+  description = "API Key for Webauthn service. DEPRECATED: use Parameter Store"
   type        = string
   default     = ""
 }
 
 variable "mfa_webauthn_apisecret" {
-  description = "API Key for Webauthn service. DEPRECATED: use mfa_api_secret"
+  description = "API Key for Webauthn service. DEPRECATED: use Parameter Store"
   type        = string
   default     = ""
 }


### PR DESCRIPTION

### Changed
- Revert the addition of `mfa_api_key` and `mfa_api_secret` and recommend Parameter Store instead. (The `coalesce` function fails if none of its parameters evaluates to a non-empty value. It's irrelevant anyway since the coalesce happens in idp-id-broker also.)
