### PR TITLE
Release 12.14.3 -- deprecate auth_saml_entityId and calculate the value

### DIFF
--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -74,7 +74,7 @@ locals {
     aws_region                          = local.aws_region
     cloudwatch_log_group_name           = var.cloudwatch_log_group_name
     auth_saml_checkResponseSigning      = var.auth_saml_checkResponseSigning
-    auth_saml_entityId                  = var.auth_saml_entityId
+    auth_saml_entityId                  = coalesce(var.auth_saml_entityId, "${var.api_subdomain}.${var.cloudflare_domain}")
     auth_saml_idpCertificate            = var.auth_saml_idpCertificate
     auth_saml_requireEncryptedAssertion = var.auth_saml_requireEncryptedAssertion
     auth_saml_signRequest               = var.auth_saml_signRequest

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -38,7 +38,7 @@ variable "auth_saml_checkResponseSigning" {
 }
 
 variable "auth_saml_entityId" {
-  description = "SP entity ID"
+  description = "SP entity ID. DEPRECATED: future versions will use \"$${var.api_subdomain}.$${var.cloudflare_domain}\""
   type        = string
 }
 


### PR DESCRIPTION
### Deprecated
- Deprecate `auth_saml_entityId` and calculate the value