### PR TITLE
Release 12.15.0 -- add rule alpha numeric

### DIFF
--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -105,6 +105,7 @@ locals {
     mysql_password                      = var.mysql_pass
     mysql_user                          = var.mysql_user
     parameter_store_path                = local.parameter_store_path
+    password_rule_alpha_and_numeric     = var.password_rule_alpha_and_numeric
     password_rule_enablehibp            = var.password_rule_enablehibp
     password_rule_maxlength             = var.password_rule_maxlength
     password_rule_minlength             = var.password_rule_minlength

--- a/terraform/050-pw-manager/task-definition-api.json
+++ b/terraform/050-pw-manager/task-definition-api.json
@@ -178,6 +178,10 @@
         "value": "${password_rule_minscore}"
       },
       {
+        "name": "PASSWORD_RULE_requireAlphaAndNumeric",
+        "value": "${password_rule_alpha_and_numeric}"
+      },
+      {
         "name": "RECAPTCHA_SECRET_KEY",
         "value": "${recaptcha_secret_key}"
       },

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -210,6 +210,12 @@ variable "mysql_user" {
   type = string
 }
 
+variable "password_rule_alpha_and_numeric" {
+  description = "require alpha and numeric characters in password, use \"false\" or \"true\" strings"
+  type        = string
+  default     = "false"
+}
+
 variable "password_rule_enablehibp" {
   description = "enable haveibeenpwned.com password check"
   type        = string


### PR DESCRIPTION
[IDP-1076](https://itse.youtrack.cloud/issue/IDP-1076) Require both a letter and a number in IDP passwords (to meet PCI 4.0 requirements for Wycliffe)


### Added
- Add a variable to set the requireAlphaAndNumeric password rule.
