### PR TITLE
Release 12.16.0 -- option to make the id-broker API accessible by public routes

### DIFF
--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -47,7 +47,7 @@ This module is used to create an ECS service running id-broker.
  - `vpc_id` - ID for VPC
 
 Note 1: `internal_alb_dns_name` can be omitted if `alb_dns_name` is provided
-Note 2: `internal_alb_listener_arn` can be omitted if `internal_alb_listener_arn` is provided
+Note 2: `internal_alb_listener_arn` can be omitted if `alb_listener_arn` is provided
 
 ## Optional Inputs
 

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -10,6 +10,8 @@ This module is used to create an ECS service running id-broker.
 
 ## Required Inputs
 
+ - `alb_dns_name` - DNS name for the IdP-in-a-Box's external Application Load Balancer (Note 1)
+ - `alb_listener_arn` - ARN for the IdP-in-a-Box's external ALB's listener (Note 2)
  - `app_env` - Application environment
  - `app_name` - Application name
  - `cloudflare_domain` - Top level domain name for use with Cloudflare
@@ -23,8 +25,8 @@ This module is used to create an ECS service running id-broker.
  - `email_service_validIpRanges` - List of valid IP address ranges for Email Service API
  - `help_center_url` - URL to password manager help center
  - `idp_name` - Short name of IdP for use in logs and email alerts
- - `internal_alb_dns_name` - DNS name for the IdP-in-a-Box's internal Application Load Balancer
- - `internal_alb_listener_arn` - ARN for the IdP-in-a-Box's internal ALB's listener
+ - `internal_alb_dns_name` - DNS name for the IdP-in-a-Box's internal Application Load Balancer (Note 1)
+ - `internal_alb_listener_arn` - ARN for the IdP-in-a-Box's internal ALB's listener (Note 2)
  - `mfa_totp_apibaseurl` - Base URL to TOTP api
  - `mfa_totp_apikey` - API key for TOTP api
  - `mfa_totp_apisecret` - API secret for TOTP api
@@ -44,6 +46,9 @@ This module is used to create an ECS service running id-broker.
  - `support_name` - Name for support. Default: `support`
  - `vpc_id` - ID for VPC
 
+Note 1: `internal_alb_dns_name` can be omitted if `alb_dns_name` is provided
+Note 2: `internal_alb_listener_arn` can be omitted if `internal_alb_listener_arn` is provided
+
 ## Optional Inputs
 
  - `abandoned_user_abandoned_period` - Time a user record can remain abandoned before HR is notified. Default: `+6 months`
@@ -52,6 +57,7 @@ This module is used to create an ECS service running id-broker.
  - `appconfig_app_id` - AppConfig application ID created by AWS. This cannot be the application name. Use with `appconfig_env_id`.
  - `contingent_user_duration` - How long before a new user without a primary email address expires. Default: `+4 weeks`
  - `cpu_cron` - How much CPU to allocate to cron service. Default: `128`
+ - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
  - `email_repeat_delay_days` - Don't resend the same type of email to the same user for X days. Default: `31`
  - `email_service_assertValidIp` - Whether or not to assert IP address for Email Service API is trusted
  - `email_signature` - Signature for use in emails. Default is empty string

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -94,6 +94,7 @@ Note 2: `internal_alb_listener_arn` can be omitted if `alb_listener_arn` is prov
  - `mfa_required_for_new_users` - Require MFA for all new users. Default: `false`
  - `minimum_backup_codes_before_nag` - Nag the user if they have FEWER than this number of backup codes. Default: `4` 
  - `notification_email` - Email address to send alerts/notifications to. Default: notifications disabled
+ - `output_alterate_tokens` - If true, output the second set of API tokens. Used for credential rotation. Default: `false`
  - `password_expiration_grace_period` - Grace period after `password_lifespan` after which the account will be locked. Default: `+30 days`
  - `password_lifespan` - Time span before which the user should set a new password. Default: `+1 year`
  - `password_mfa_lifespan_extension` - Extension to password lifespan for users with at least one 2-step Verification option. Default: `+4 years`

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -69,6 +69,22 @@ resource "random_id" "access_token_idsync" {
   byte_length = 16
 }
 
+resource "random_id" "access_token_pwmanager_b" {
+  byte_length = 32
+}
+
+resource "random_id" "access_token_search_b" {
+  byte_length = 32
+}
+
+resource "random_id" "access_token_ssp_b" {
+  byte_length = 32
+}
+
+resource "random_id" "access_token_idsync_b" {
+  byte_length = 32
+}
+
 /*
  * Create ECS service
  */
@@ -83,7 +99,11 @@ locals {
     random_id.access_token_pwmanager.hex,
     random_id.access_token_search.hex,
     random_id.access_token_ssp.hex,
-    random_id.access_token_idsync.hex
+    random_id.access_token_idsync.hex,
+    random_id.access_token_pwmanager_b.hex,
+    random_id.access_token_search_b.hex,
+    random_id.access_token_ssp_b.hex,
+    random_id.access_token_idsync_b.hex,
   ])
 
   subdomain_with_region = "${var.subdomain}-${local.aws_region}"

--- a/terraform/040-id-broker/outputs.tf
+++ b/terraform/040-id-broker/outputs.tf
@@ -12,19 +12,19 @@ output "db_idbroker_user" {
 }
 
 output "access_token_pwmanager" {
-  value = random_id.access_token_pwmanager.hex
+  value = var.output_alternate_tokens ? random_id.access_token_pwmanager_b.hex : random_id.access_token_pwmanager.hex
 }
 
 output "access_token_search" {
-  value = random_id.access_token_search.hex
+  value = var.output_alternate_tokens ? random_id.access_token_search_b.hex : random_id.access_token_search.hex
 }
 
 output "access_token_ssp" {
-  value = random_id.access_token_ssp.hex
+  value = var.output_alternate_tokens ? random_id.access_token_ssp_b.hex : random_id.access_token_ssp.hex
 }
 
 output "access_token_idsync" {
-  value = random_id.access_token_idsync.hex
+  value = var.output_alternate_tokens ? random_id.access_token_idsync_b.hex : random_id.access_token_idsync.hex
 }
 
 output "help_center_url" {

--- a/terraform/040-id-broker/outputs.tf
+++ b/terraform/040-id-broker/outputs.tf
@@ -2,6 +2,11 @@ output "hostname" {
   value = "${local.subdomain_with_region}.${var.cloudflare_domain}"
 }
 
+output "public_dns_value" {
+  description = "The value to use for the 'public' DNS record, if creating it outside of this module."
+  value       = cloudflare_record.brokerdns.hostname
+}
+
 output "db_idbroker_user" {
   value = var.mysql_user
 }
@@ -37,4 +42,3 @@ output "support_email" {
 output "support_name" {
   value = var.support_name
 }
-

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -189,14 +189,28 @@ variable "inactive_user_deletion_enable" {
   default = "false"
 }
 
+variable "alb_dns_name" {
+  description = "The DNS name for the IdP-in-a-Box's external Application Load Balancer."
+  type        = string
+  default     = ""
+}
+
+variable "alb_listener_arn" {
+  description = "The ARN for the IdP-in-a-Box's external ALB's listener."
+  type        = string
+  default     = ""
+}
+
 variable "internal_alb_dns_name" {
   description = "The DNS name for the IdP-in-a-Box's internal Application Load Balancer."
   type        = string
+  default     = ""
 }
 
 variable "internal_alb_listener_arn" {
   description = "The ARN for the IdP-in-a-Box's internal ALB's listener."
   type        = string
+  default     = ""
 }
 
 variable "invite_email_delay_seconds" {
@@ -612,4 +626,10 @@ variable "appconfig_env_id" {
   description = "DEPRECATED"
   type        = string
   default     = ""
+}
+
+variable "create_dns_record" {
+  description = "Controls creation of a DNS CNAME record for the ECS service."
+  type        = bool
+  default     = true
 }

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -633,3 +633,9 @@ variable "create_dns_record" {
   type        = bool
   default     = true
 }
+
+variable "output_alternate_tokens" {
+  description = "Output alternate tokens for client services. Used for token rotation."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
[IDP-1472](https://itse.youtrack.cloud/issue/IDP-1472) add idp-id-broker to public routes
and
[IDP-1500](https://itse.youtrack.cloud/issue/IDP-1500) allow for API key rotation

---

### Added
- Added new inputs (`alb_dns_name`, `alb_listener_arn`) to the id-broker module to connect to the public load balancer.
- Added new input (`create_dns_record`) to the id-broker module to create a public DNS record.
- Added id-broker load balancer configuration to make connections "sticky". This keeps a client's connection established with a consistent container.
- Added alternate API tokens to id-broker for credential rotation. The new tokens are 32 bytes in length rather than the 16 bytes used by the original tokens.
