### PR TITLE
Release 12.18.1 -- fix email permissions and config

### DIFF
--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -297,6 +297,7 @@ module "email_service" {
   service_env        = var.app_env
   container_def_json = local.email_task_def
   desired_count      = var.enable_email_service ? 1 : 0
+  task_role_arn      = module.ecs_role.role_arn
 }
 
 

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -379,6 +379,25 @@ resource "aws_iam_role_policy" "parameter_store" {
   })
 }
 
+resource "aws_iam_role_policy" "ses" {
+  name = "ses"
+  role = module.ecs_role.role_name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "SendEmail"
+      Effect   = "Allow"
+      Action   = "ses:SendEmail"
+      Resource = "*"
+      Condition = {
+        StringEquals = {
+          "ses:FromAddress" = var.from_email
+        }
+      }
+    }]
+  })
+}
+
 resource "aws_iam_user_policy_attachment" "cd" {
   user       = var.cduser_username
   policy_arn = aws_iam_policy.cd.arn

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -280,6 +280,7 @@ locals {
   email_task_def = templatefile("${path.module}/task-definition.json", merge(
     local.task_def_vars,
     {
+      name    = "email"
       command = "/data/run-cron.sh"
       memory  = var.memory_email
       cpu     = var.cpu_email

--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -126,12 +126,15 @@ locals {
     cpu                                        = var.cpu
     db_name                                    = var.db_name
     docker_image                               = var.docker_image
+    email_brand_color                          = var.email_brand_color
+    email_brand_logo                           = var.email_brand_logo
     email_repeat_delay_days                    = var.email_repeat_delay_days
     email_service_accessToken                  = var.email_service_accessToken
     email_service_assertValidIp                = var.email_service_assertValidIp
     email_service_baseUrl                      = var.email_service_baseUrl
     email_service_validIpRanges                = join(",", var.email_service_validIpRanges)
     email_signature                            = var.email_signature
+    from_email                                 = var.from_email
     ga_api_secret                              = var.ga_api_secret
     ga_client_id                               = var.ga_client_id
     ga_measurement_id                          = var.ga_measurement_id

--- a/terraform/040-id-broker/task-definition.json
+++ b/terraform/040-id-broker/task-definition.json
@@ -61,6 +61,14 @@
         "value": "${contingent_user_duration}"
       },
       {
+        "name": "EMAIL_BRAND_COLOR",
+        "value": "${email_brand_color}"
+      },
+      {
+          "name": "EMAIL_BRAND_LOGO",
+          "value": "${email_brand_logo}"
+      },
+      {
         "name": "EMAIL_REPEAT_DELAY_DAYS",
         "value": "${email_repeat_delay_days}"
       },
@@ -83,6 +91,10 @@
       {
         "name": "EMAIL_SIGNATURE",
         "value": "${email_signature}"
+      },
+      {
+        "name": "FROM_EMAIL",
+        "value": "${from_email}"
       },
       {
         "name": "GA_API_SECRET",

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -86,6 +86,24 @@ variable "email_repeat_delay_days" {
   default = "31"
 }
 
+variable "email_brand_color" {
+  description = <<EOT
+    EXPERIMENTAL: The CSS color to use for branding in emails (e.g. `rgb(0, 93, 154)`). Required for idp-id-broker
+    version 8.0.0 or higher.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "email_brand_logo" {
+  description = <<EOT
+    EXPERIMENTAL: The fully qualified URL to an image for use as logo in emails. Required for idp-id-broker version
+    8.0.0 or higher.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "email_service_accessToken" {
   description = "Access Token for Email Service API"
   type        = string
@@ -114,8 +132,8 @@ variable "email_signature" {
 
 variable "enable_email_service" {
   description = <<EOT
-    EXPERIMENTAL: Enable the email service, replacing the separate email-service module. Requires idp-id-broker
-    version 7.4.0 or later.
+    EXPERIMENTAL: Enable the email service, replacing the separate email-service module.  Required for idp-id-broker
+    version 8.0.0 or higher.
   EOT
   type        = bool
   default     = false
@@ -124,6 +142,15 @@ variable "enable_email_service" {
 variable "event_schedule" {
   type    = string
   default = "cron(0 0 * * ? *)"
+}
+
+variable "from_email" {
+  description = <<EOT
+    EXPERIMENTAL: Email address provided on the FROM header of email notifications. Required for idp-id-broker version
+    8.0.0 or higher.
+  EOT
+  type        = string
+  default     = ""
 }
 
 variable "ga_api_secret" {


### PR DESCRIPTION
### Fixed
- Fixed permission issue in id-broker email container
- Name the email container "email" rather than "web" to send logs to the correct stream
- Added SES permission to id-broker task role
- Added email variables to id-broker task definition
