### PR TITLE
add use_broker_email_service variable and deprecation notices

### DIFF
--- a/terraform/031-email-service/README.md
+++ b/terraform/031-email-service/README.md
@@ -1,6 +1,20 @@
 # 031-email-service - ECS service for email-service
 This module is used to create an ECS service running email-service.
 
+# Deprecation notice
+
+This service will be removed in the next major version. It is being replaced by the email service integrated within
+the id-broker module. In preparation, upgrade idp-id-broker to version 8 or later, set the `use_broker_email_service`
+variable to "true" in the pw-manager and id-sync module, and define the following variables in the id-broker module:
+
+- email_brand_color
+- email_brand_logo
+- from_email
+- from_name
+- enable_email_service
+- cpu_email
+- memory_email
+
 ## What this does
 
  - Create task definition and ECS service for email-service API

--- a/terraform/040-id-broker/README.md
+++ b/terraform/040-id-broker/README.md
@@ -56,13 +56,20 @@ Note 2: `internal_alb_listener_arn` can be omitted if `alb_listener_arn` is prov
  - `abandoned_user_deactivate_instructions_url` - URL for instruction on how to deactivate user accounts, referenced in notification email. Default: (none)
  - `appconfig_app_id` - AppConfig application ID created by AWS. This cannot be the application name. Use with `appconfig_env_id`.
  - `contingent_user_duration` - How long before a new user without a primary email address expires. Default: `+4 weeks`
- - `cpu_cron` - How much CPU to allocate to cron service. Default: `128`
+ - `cpu` - Amount of CPU (AWS CPU units, 1000 = 1 cpu) to allocate to primary container. Default: `250`
+ - `cpu_cron` - How much CPU (AWS CPU units, 1000 = 1 cpu) to allocate to cron service. Default: `128`
+ - `cpu_email` - Amount of CPU (AWS CPU units, 1000 = 1 cpu) to allocate to email container. Default: `64`
  - `create_dns_record` - Controls creation of a DNS CNAME record for the ECS service. Default: `true`
+ - `email_brand_color` - The CSS color to use for branding in emails (e.g. `rgb(0, 93, 154)`). Required for idp-id-broker version 8.0.0 or higher. Default: `"#005D99"` (blue)
+ - `email_brand_logo` - The fully qualified URL to an image for use as logo in emails. Required for idp-id-broker version 8.0.0 or higher. Default: `""` (email header will show a "broken link" icon)
  - `email_repeat_delay_days` - Don't resend the same type of email to the same user for X days. Default: `31`
  - `email_service_assertValidIp` - Whether or not to assert IP address for Email Service API is trusted
  - `email_signature` - Signature for use in emails. Default is empty string
+ - `enable_email_service` - Enable the email service, replacing the separate email-service module.  Required for idp-id-broker version 8.0.0 or higher. Default: `false`
  - `appconfig_env_id` - AppConfig environment ID created by AWS. This cannot be the environment name. Use with `appconfig_app_id`.
  - `event_schedule` - Task run schedule. Default: `cron(0 0 * * ? *)`
+ - `from_email` - Email address provided on the FROM header of email notifications. Required for idp-id-broker version 8.0.0 or higher. Default: `""`
+ - `from_name` - Email address provided on the FROM header of email notifications. Default: `""`
  - `ga_api_secret` - The Google Analytics API secret for the data stream (e.g. aB-abcdef7890123456789)
  - `ga_client_id` - Used by Google Analytics to distinguish the user (e.g. IDP-<the idp name>-ID-BROKER)
  - `ga_measurement_id` - The Google Analytics data stream id (e.g. G-ABCDE67890)
@@ -80,7 +87,9 @@ Note 2: `internal_alb_listener_arn` can be omitted if `alb_listener_arn` is prov
  - `invite_grace_period` - Grace period after the invite lifespan, after which the invite will be deleted. Default: `+3 months`
  - `invite_lifespan` - Time span before the invite code expires. Default: `+1 month`
  - `lost_security_key_email_days` - The number of days of not using a security key after which we email the user. Default: `62`
- - `memory_cron` - How much memory to allocate to cron service. Default: `64`
+ - `memory` - Amount of memory (MB) to allocate to primary container. Default: `200`
+ - `memory_cron` - How much memory (MB) to allocate to cron service. Default: `64`
+ - `memory_email` - Amount of memory (MB) to allocate to email container. Default: `64`
  - `method_add_interval` Interval between reminders to add recovery methods. Default: `+6 months`
  - `method_codeLength` - Number of digits in recovery method verification code. Default: `6`
  - `method_gracePeriod` - If a recovery method has been expired longer than this amount of time, it will be removed. Default: `+1 week`

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -88,7 +88,7 @@ variable "email_repeat_delay_days" {
 
 variable "email_brand_color" {
   description = <<EOT
-    EXPERIMENTAL: The CSS color to use for branding in emails (e.g. `rgb(0, 93, 154)`). Required for idp-id-broker
+    The CSS color to use for branding in emails (e.g. `rgb(0, 93, 154)`). Required for idp-id-broker
     version 8.0.0 or higher.
   EOT
   type        = string
@@ -97,7 +97,7 @@ variable "email_brand_color" {
 
 variable "email_brand_logo" {
   description = <<EOT
-    EXPERIMENTAL: The fully qualified URL to an image for use as logo in emails. Required for idp-id-broker version
+    The fully qualified URL to an image for use as logo in emails. Required for idp-id-broker version
     8.0.0 or higher.
   EOT
   type        = string
@@ -132,7 +132,7 @@ variable "email_signature" {
 
 variable "enable_email_service" {
   description = <<EOT
-    EXPERIMENTAL: Enable the email service, replacing the separate email-service module.  Required for idp-id-broker
+    Enable the email service, replacing the separate email-service module.  Required for idp-id-broker
     version 8.0.0 or higher.
   EOT
   type        = bool
@@ -146,7 +146,7 @@ variable "event_schedule" {
 
 variable "from_email" {
   description = <<EOT
-    EXPERIMENTAL: Email address provided on the FROM header of email notifications. Required for idp-id-broker version
+    Email address provided on the FROM header of email notifications. Required for idp-id-broker version
     8.0.0 or higher.
   EOT
   type        = string

--- a/terraform/050-pw-manager/main-api.tf
+++ b/terraform/050-pw-manager/main-api.tf
@@ -61,6 +61,18 @@ resource "random_id" "access_token_hash" {
  */
 locals {
   api_subdomain_with_region = "${var.api_subdomain}-${local.aws_region}"
+  email_service_accessToken = (
+    var.use_broker_email_service ? var.id_broker_access_token : var.email_service_accessToken
+  )
+  email_service_assertValidIp = (
+    var.use_broker_email_service ? var.id_broker_assertValidBrokerIp : var.email_service_assertValidIp
+  )
+  email_service_baseUrl = (
+    var.use_broker_email_service ? var.id_broker_base_uri : var.email_service_baseUrl
+  )
+  email_service_validIpRanges = (
+    var.use_broker_email_service ? join(",", var.id_broker_validIpRanges) : join(",", var.email_service_validIpRanges)
+  )
 
   task_def = templatefile("${path.module}/task-definition-api.json", {
     appconfig_app_id                    = var.appconfig_app_id
@@ -87,10 +99,10 @@ locals {
     cpu                                 = var.cpu
     db_name                             = var.db_name
     docker_image                        = var.docker_image
-    email_service_accessToken           = var.email_service_accessToken
-    email_service_assertValidIp         = var.email_service_assertValidIp
-    email_service_baseUrl               = var.email_service_baseUrl
-    email_service_validIpRanges         = join(",", var.email_service_validIpRanges)
+    email_service_accessToken           = local.email_service_accessToken
+    email_service_assertValidIp         = local.email_service_assertValidIp
+    email_service_baseUrl               = local.email_service_baseUrl
+    email_service_validIpRanges         = local.email_service_validIpRanges
     email_signature                     = var.email_signature
     extra_hosts                         = var.extra_hosts
     help_center_url                     = var.help_center_url

--- a/terraform/050-pw-manager/vars.tf
+++ b/terraform/050-pw-manager/vars.tf
@@ -133,23 +133,35 @@ variable "ecsServiceRole_arn" {
 }
 
 variable "email_service_accessToken" {
-  description = "Access Token for Email Service API"
+  description = <<EOT
+    Access Token for Email Service API
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = string
 }
 
 variable "email_service_assertValidIp" {
-  description = "Whether or not to assert IP address for Email Service API is trusted"
+  description = <<EOT
+    Whether or not to assert IP address for Email Service API is trusted
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = string
   default     = "true"
 }
 
 variable "email_service_baseUrl" {
-  description = "Base URL to Email Service API"
+  description = <<EOT
+    Base URL to Email Service API
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = string
 }
 
 variable "email_service_validIpRanges" {
-  description = "List of valid IP ranges to Email Service API"
+  description = <<EOT
+    List of valid IP ranges to Email Service API
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = list(string)
 }
 
@@ -286,6 +298,15 @@ variable "support_url" {
 
 variable "ui_subdomain" {
   type = string
+}
+
+variable "use_broker_email_service" {
+  description = <<EOT
+    Use the email service capability bundled in id-broker instead of the separate email-service service. NOTICE: this
+    will default to true in the next major version.
+  EOT
+  type        = string
+  default     = "false"
 }
 
 variable "vpc_id" {

--- a/terraform/070-id-sync/main.tf
+++ b/terraform/070-id-sync/main.tf
@@ -15,6 +15,19 @@ locals {
     })]
   )
 
+  email_service_accessToken = (
+    var.use_broker_email_service ? var.id_broker_access_token : var.email_service_accessToken
+  )
+  email_service_assertValidIp = (
+    var.use_broker_email_service ? var.id_broker_assertValidIp : var.email_service_assertValidIp
+  )
+  email_service_baseUrl = (
+    var.use_broker_email_service ? var.id_broker_base_url : var.email_service_baseUrl
+  )
+  email_service_validIpRanges = (
+    var.use_broker_email_service ? join(",", var.id_broker_trustedIpRanges) : join(",", var.email_service_validIpRanges)
+  )
+
   task_def = templatefile("${path.module}/task-definition.json", {
     appconfig_app_id             = var.appconfig_app_id
     appconfig_env_id             = var.appconfig_env_id
@@ -24,10 +37,10 @@ locals {
     aws_region                   = local.aws_region
     cloudwatch_log_group_name    = var.cloudwatch_log_group_name
     docker_image                 = var.docker_image
-    email_service_accessToken    = var.email_service_accessToken
-    email_service_assertValidIp  = var.email_service_assertValidIp
-    email_service_baseUrl        = var.email_service_baseUrl
-    email_service_validIpRanges  = join(",", var.email_service_validIpRanges)
+    email_service_accessToken    = local.email_service_accessToken
+    email_service_assertValidIp  = local.email_service_assertValidIp
+    email_service_baseUrl        = local.email_service_baseUrl
+    email_service_validIpRanges  = local.email_service_validIpRanges
     id_broker_access_token       = var.id_broker_access_token
     id_broker_adapter            = var.id_broker_adapter
     id_broker_assertValidIp      = var.id_broker_assertValidIp

--- a/terraform/070-id-sync/vars.tf
+++ b/terraform/070-id-sync/vars.tf
@@ -26,23 +26,35 @@ variable "docker_image" {
 }
 
 variable "email_service_accessToken" {
-  description = "Access Token for Email Service API"
+  description = <<EOT
+    Access Token for Email Service API
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = string
 }
 
 variable "email_service_assertValidIp" {
-  description = "Whether or not to assert IP address for Email Service API is trusted"
+  description = <<EOT
+    Whether or not to assert IP address for Email Service API is trusted
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = string
   default     = "true"
 }
 
 variable "email_service_baseUrl" {
-  description = "Base URL to Email Service API"
+  description = <<EOT
+    Base URL to Email Service API
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = string
 }
 
 variable "email_service_validIpRanges" {
-  description = "List of valid IP ranges to Email Service API"
+  description = <<EOT
+    List of valid IP ranges to Email Service API
+    DEPRECATED: This will be removed in the next major version. Use the email service integrated in id-broker.
+  EOT
   type        = list(string)
 }
 
@@ -159,4 +171,13 @@ variable "appconfig_env_id" {
   description = "DEPRECATED"
   type        = string
   default     = ""
+}
+
+variable "use_broker_email_service" {
+  description = <<EOT
+    Use the email service capability bundled in id-broker instead of the separate email-service service. NOTICE: this
+    will default to true in the next major version.
+  EOT
+  type        = string
+  default     = "false"
 }


### PR DESCRIPTION
[IDP-1444](https://support.gtis.sil.org/issue/IDP-1444) integrate email-service into idp-id-broker

---

### Added
- Added `use_broker_email_service` variable to pw-manager and id-sync modules.
- Added deprecation notices for the standalone email-service module.
- Added documentation for transition to broker email service.