### PR TITLE
Update which ECS Services are shown in CloudWatch Dashboard

### DIFF
--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -127,12 +127,9 @@ module "ecs-service-cloudwatch-dashboard" {
   dashboard_name = "${var.app_name}-${var.app_env}-${data.aws_region.current.name}"
 
   service_names = [
-    "${var.idp_name}-db-backup",
     "${var.idp_name}-email-service-api",
     "${var.idp_name}-email-service-cron",
     "${var.idp_name}-id-broker",
-    "${var.idp_name}-id-broker-cron",
-    "${var.idp_name}-id-sync",
     "${var.idp_name}-phpmyadmin",
     "${var.idp_name}-pw-manager",
     "${var.idp_name}-simplesamlphp",

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -128,6 +128,7 @@ module "ecs-service-cloudwatch-dashboard" {
 
   service_names = [
     "${var.idp_name}-id-broker",
+    "${var.idp_name}-id-broker-email",
     "${var.idp_name}-phpmyadmin",
     "${var.idp_name}-pw-manager",
     "${var.idp_name}-simplesamlphp",

--- a/terraform/010-cluster/main.tf
+++ b/terraform/010-cluster/main.tf
@@ -127,8 +127,6 @@ module "ecs-service-cloudwatch-dashboard" {
   dashboard_name = "${var.app_name}-${var.app_env}-${data.aws_region.current.name}"
 
   service_names = [
-    "${var.idp_name}-email-service-api",
-    "${var.idp_name}-email-service-cron",
     "${var.idp_name}-id-broker",
     "${var.idp_name}-phpmyadmin",
     "${var.idp_name}-pw-manager",


### PR DESCRIPTION
[IDP-1583](https://support.gtis.sil.org/issue/IDP-1583) Remove scheduled tasks from our IDPs' CloudWatch Dashboard configuration (managed by terraform)

---

### Added
- Add new id-broker-email service to CloudWatch Dashboard

### Removed
- Remove email-service-api/-cron from CloudWatch Dashboard
  * We no longer use those, and we plan to remove them. Sending emails was moved into ID Broker.

### Fixed
- Remove ECS Scheduled Tasks from CloudWatch Dashboard
  * The dashboard is only useful for long-running services/tasks, not scheduled tasks.