### PR TITLE
remove the cd user policy if a role is available

### DIFF
--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -378,6 +378,8 @@ resource "aws_iam_role_policy" "ses" {
 }
 
 resource "aws_iam_user_policy_attachment" "cd" {
+  count = var.cd_role_name == null ? 1 : 0
+
   user       = var.cduser_username
   policy_arn = aws_iam_policy.cd.arn
 }

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -196,6 +196,8 @@ resource "aws_iam_role_policy" "parameter_store" {
 }
 
 resource "aws_iam_user_policy_attachment" "cd" {
+  count = var.cd_role_name == null ? 1 : 0
+
   user       = var.cduser_username
   policy_arn = aws_iam_policy.cd.arn
 }

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -190,6 +190,8 @@ resource "aws_iam_role_policy" "parameter_store" {
 }
 
 resource "aws_iam_user_policy_attachment" "cd" {
+  count = var.cd_role_name == null ? 1 : 0
+
   user       = var.cduser_username
   policy_arn = aws_iam_policy.cd.arn
 }


### PR DESCRIPTION
[IDP-1926](https://support.gtis.sil.org/issue/IDP-1926) convert IdP to use a role for deployment

---

### Changed
- Detach the cd user policy from the services if a cd role is defined. This will allow the user to be deleted after transitioning to the role.