### PR TITLE
move database passwords to SSM

### DIFF
--- a/modules/032-db-backup/README.md
+++ b/modules/032-db-backup/README.md
@@ -28,6 +28,7 @@ module "dbbackup" {
   db_names                  = var.db_names
   docker_image              = data.terraform_remote_state.ecr.ecr_repo_dbbackup
   ecs_cluster_id            = data.terraform_remote_state.core.ecs_cluster_id
+  task_execution_role_arn   = data.terraform_remote_state.core.task_execution_role_arn
   idp_name                  = var.idp_name
   memory                    = var.memory
   mysql_host                = data.terraform_remote_state.database.rds_address

--- a/modules/032-db-backup/README.md
+++ b/modules/032-db-backup/README.md
@@ -31,7 +31,6 @@ module "dbbackup" {
   idp_name                  = var.idp_name
   memory                    = var.memory
   mysql_host                = data.terraform_remote_state.database.rds_address
-  mysql_pass                = data.terraform_remote_state.database.mysql_pass
   mysql_user                = data.terraform_remote_state.database.mysql_user
   service_mode              = var.service_mode
 }

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -79,34 +79,37 @@ resource "aws_s3_bucket_public_access_block" "backup" {
 }
 
 /*
- * Create user for putting backup files into the bucket
+ * Create role for putting backup files into the bucket
  */
-resource "aws_iam_user" "backup" {
+resource "aws_iam_role" "backup" {
   name = var.backup_user_name == null ? "db-backup-${var.idp_name}-${var.app_env}" : var.backup_user_name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "ECSAssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = ["ecs-tasks.amazonaws.com"] }
+      Action    = "sts:AssumeRole"
+      Condition = {
+        ArnLike      = { "aws:SourceArn" = "arn:aws:ecs:${local.aws_region}:${local.aws_account}:*" }
+        StringEquals = { "aws:SourceAccount" = local.aws_account }
+      }
+    }]
+  })
 }
 
-resource "aws_iam_access_key" "backup" {
-  user = aws_iam_user.backup.name
-}
-
-resource "aws_iam_user_policy" "backup" {
+resource "aws_iam_role_policy" "backup" {
   name = "S3-DB-Backup"
-  user = aws_iam_user.backup.name
+  role = aws_iam_role.backup.name
 
-  policy = jsonencode(
-    {
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect = "Allow"
-          Action = [
-            "s3:PutObject",
-          ]
-          Resource = "${aws_s3_bucket.backup.arn}*"
-        },
-      ]
-    }
-  )
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:PutObject"]
+      Resource = "${aws_s3_bucket.backup.arn}*"
+    }]
+  })
 }
 
 /*
@@ -119,8 +122,6 @@ locals {
     ssl_ca_base64             = var.ssl_ca_base64
     aws_region                = local.aws_region
     cloudwatch_log_group_name = var.cloudwatch_log_group_name
-    aws_access_key            = aws_iam_access_key.backup.id
-    aws_secret_key            = aws_iam_access_key.backup.secret
     cpu                       = var.cpu
     db_names                  = join(" ", var.db_names)
     docker_image              = var.docker_image
@@ -156,6 +157,8 @@ resource "aws_ecs_task_definition" "cron_td" {
   family                = "${var.idp_name}-${var.app_name}-${var.app_env}"
   container_definitions = local.task_def_backup
   network_mode          = "bridge"
+  execution_role_arn    = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn         = aws_iam_role.backup.arn
 }
 
 /*
@@ -220,4 +223,42 @@ resource "aws_ssm_parameter" "b2_application_key" {
   type        = "SecureString"
   value       = var.b2_application_key
   description = "Value set by Terraform -- do not change manually."
+}
+
+/*
+ * ECS Task Execution Role to allow ECS to assume a role for access to SSM Parameter Store
+ */
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecs-task-execution-${var.app_name}-${var.app_env}-${local.aws_region}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_task_execution_ssm_policy" {
+  name = "ssm-parameter-access"
+  role = aws_iam_role.ecs_task_execution_role.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["ssm:GetParameters"]
+        Resource = [
+          "arn:aws:ssm:${local.aws_region}:${local.aws_account}:parameter${local.parameter_path}*"
+        ]
+      }
+    ]
+  })
 }

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -1,6 +1,7 @@
 locals {
-  aws_account = data.aws_caller_identity.this.account_id
-  aws_region  = data.aws_region.current.name
+  aws_account    = data.aws_caller_identity.this.account_id
+  aws_region     = data.aws_region.current.name
+  parameter_path = "/idp-${var.idp_name}/"
   rds_arn = (
     coalesce(
       var.rds_arn,
@@ -124,12 +125,12 @@ locals {
     db_names                  = join(" ", var.db_names)
     docker_image              = var.docker_image
     mysql_host                = var.mysql_host
-    mysql_pass                = var.mysql_pass
     mysql_user                = var.mysql_user
     memory                    = var.memory
     s3_bucket                 = aws_s3_bucket.backup.bucket
     sentry_dsn                = var.sentry_dsn
     service_mode              = var.service_mode
+    parameter_store_path      = local.parameter_path
   })
 }
 
@@ -206,7 +207,7 @@ module "s3_to_b2_sync" {
 resource "aws_ssm_parameter" "b2_application_key_id" {
   count = var.enable_s3_to_b2_sync ? 1 : 0
 
-  name        = "/idp-${var.idp_name}/b2_application_key_id"
+  name        = "${local.parameter_path}b2_application_key_id"
   type        = "SecureString"
   value       = var.b2_application_key_id
   description = "Value set by Terraform -- do not change manually."
@@ -215,7 +216,7 @@ resource "aws_ssm_parameter" "b2_application_key_id" {
 resource "aws_ssm_parameter" "b2_application_key" {
   count = var.enable_s3_to_b2_sync ? 1 : 0
 
-  name        = "/idp-${var.idp_name}/b2_application_key"
+  name        = "${local.parameter_path}b2_application_key"
   type        = "SecureString"
   value       = var.b2_application_key
   description = "Value set by Terraform -- do not change manually."

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -1,7 +1,7 @@
 locals {
-  aws_account    = data.aws_caller_identity.this.account_id
-  aws_region     = data.aws_region.current.name
-  parameter_path = "/idp-${var.idp_name}/"
+  aws_account          = data.aws_caller_identity.this.account_id
+  aws_region           = data.aws_region.current.name
+  parameter_store_path = "/idp-${var.idp_name}/"
   rds_arn = (
     coalesce(
       var.rds_arn,
@@ -131,7 +131,7 @@ locals {
     s3_bucket                 = aws_s3_bucket.backup.bucket
     sentry_dsn                = var.sentry_dsn
     service_mode              = var.service_mode
-    parameter_store_path      = local.parameter_path
+    parameter_store_path      = local.parameter_store_path
   })
 }
 
@@ -157,7 +157,7 @@ resource "aws_ecs_task_definition" "cron_td" {
   family                = "${var.idp_name}-${var.app_name}-${var.app_env}"
   container_definitions = local.task_def_backup
   network_mode          = "bridge"
-  execution_role_arn    = aws_iam_role.ecs_task_execution_role.arn
+  execution_role_arn    = var.task_execution_role_arn
   task_role_arn         = aws_iam_role.backup.arn
 }
 
@@ -210,7 +210,7 @@ module "s3_to_b2_sync" {
 resource "aws_ssm_parameter" "b2_application_key_id" {
   count = var.enable_s3_to_b2_sync ? 1 : 0
 
-  name        = "${local.parameter_path}b2_application_key_id"
+  name        = "${local.parameter_store_path}b2_application_key_id"
   type        = "SecureString"
   value       = var.b2_application_key_id
   description = "Value set by Terraform -- do not change manually."
@@ -219,46 +219,8 @@ resource "aws_ssm_parameter" "b2_application_key_id" {
 resource "aws_ssm_parameter" "b2_application_key" {
   count = var.enable_s3_to_b2_sync ? 1 : 0
 
-  name        = "${local.parameter_path}b2_application_key"
+  name        = "${local.parameter_store_path}b2_application_key"
   type        = "SecureString"
   value       = var.b2_application_key
   description = "Value set by Terraform -- do not change manually."
-}
-
-/*
- * ECS Task Execution Role to allow ECS to assume a role for access to SSM Parameter Store
- */
-
-resource "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecs-task-execution-${var.app_name}-${var.app_env}-${local.aws_region}"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Principal = { Service = "ecs-tasks.amazonaws.com" }
-      Action    = "sts:AssumeRole"
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
-  role       = aws_iam_role.ecs_task_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-}
-
-resource "aws_iam_role_policy" "ecs_task_execution_ssm_policy" {
-  name = "ssm-parameter-access"
-  role = aws_iam_role.ecs_task_execution_role.id
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = ["ssm:GetParameters"]
-        Resource = [
-          "arn:aws:ssm:${local.aws_region}:${local.aws_account}:parameter${local.parameter_path}*"
-        ]
-      }
-    ]
-  })
 }

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -16,14 +16,6 @@
     "dockerSecurityOptions": null,
     "environment": [
       {
-        "name": "AWS_ACCESS_KEY",
-        "value": "${aws_access_key}"
-      },
-      {
-        "name": "AWS_SECRET_KEY",
-        "value": "${aws_secret_key}"
-      },
-      {
         "name": "DB_NAMES",
         "value": "${db_names}"
       },

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -40,10 +40,6 @@
         "value": "${mysql_host}"
       },
       {
-        "name": "MYSQL_PASSWORD",
-        "value": "${mysql_pass}"
-      },
-      {
         "name": "MYSQL_USER",
         "value": "${mysql_user}"
       },
@@ -55,6 +51,12 @@
         "name": "SENTRY_DSN",
         "value": "${sentry_dsn}"
       }
+    ],
+    "secrets": [
+        {
+          "name": "MYSQL_PASSWORD",
+          "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
+        }
     ],
     "links": null,
     "workingDirectory": null,

--- a/modules/032-db-backup/test.tftest.hcl
+++ b/modules/032-db-backup/test.tftest.hcl
@@ -13,6 +13,7 @@ mock_provider "aws" {
 
 variables {
   app_env                   = "test"
+  task_execution_role_arn   = ""
   cloudwatch_log_group_name = ""
   docker_image              = ""
   ecs_cluster_id            = ""

--- a/modules/032-db-backup/test.tftest.hcl
+++ b/modules/032-db-backup/test.tftest.hcl
@@ -18,7 +18,6 @@ variables {
   ecs_cluster_id            = ""
   idp_name                  = ""
   mysql_host                = ""
-  mysql_pass                = ""
   mysql_user                = ""
 }
 

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -73,11 +73,6 @@ variable "mysql_host" {
   type        = string
 }
 
-variable "mysql_pass" {
-  description = "MySQL password"
-  type        = string
-}
-
 variable "mysql_user" {
   description = "MySQL username"
   type        = string

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -108,6 +108,14 @@ variable "service_mode" {
   default     = "backup"
 }
 
+variable "task_execution_role_arn" {
+  description = <<-EOT
+    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    SSM Parameter Store.
+  EOT
+  type        = string
+}
+
 /*
  * AWS Backup
  */

--- a/modules/040-id-broker/README.md
+++ b/modules/040-id-broker/README.md
@@ -32,6 +32,7 @@ module "broker" {
   email_repeat_delay_days          = var.email_repeat_delay_days
   ecs_cluster_id                   = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn               = data.terraform_remote_state.core.ecsServiceRole_arn
+  task_execution_role_arn          = data.terraform_remote_state.core.task_execution_role_arn
   email_signature                  = var.email_signature
   event_schedule                   = "cron(1 0 * * ? 0)"
   google_config                    = var.google_config

--- a/modules/040-id-broker/README.md
+++ b/modules/040-id-broker/README.md
@@ -67,7 +67,6 @@ module "broker" {
   rp_origins                       = var.rp_origins
   minimum_backup_codes_before_nag  = var.minimum_backup_codes_before_nag
   mysql_host                       = data.terraform_remote_state.database.rds_address
-  mysql_pass                       = data.terraform_remote_state.database.db_idbroker_pass
   mysql_user                       = var.mysql_user
   notification_email               = var.notification_email
   password_expiration_grace_period = var.password_expiration_grace_period

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -165,7 +165,6 @@ locals {
     minimum_backup_codes_before_nag            = var.minimum_backup_codes_before_nag
     mfa_webauthn_rpid                          = var.cloudflare_domain
     mysql_host                                 = var.mysql_host
-    mysql_pass                                 = var.mysql_pass
     mysql_user                                 = var.mysql_user
     name                                       = "web"
     notification_email                         = var.notification_email

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -229,6 +229,7 @@ module "ecsservice" {
   container_def_json = local.task_def
   desired_count      = var.desired_count
   task_role_arn      = module.ecs_role.role_arn
+  execution_role_arn = var.task_execution_role_arn
 
   load_balancer = [{
     target_group_arn = aws_alb_target_group.broker.arn

--- a/modules/040-id-broker/task-definition.json.tftpl
+++ b/modules/040-id-broker/task-definition.json.tftpl
@@ -210,10 +210,6 @@
         "value": "${mysql_host}"
       },
       {
-        "name": "MYSQL_PASSWORD",
-        "value": "${mysql_pass}"
-      },
-      {
         "name": "MYSQL_USER",
         "value": "${mysql_user}"
       },
@@ -405,6 +401,12 @@
         "name": "SUPPORT_NAME",
         "value": "${support_name}"
       }
+    ],
+    "secrets": [
+        {
+          "name": "MYSQL_PASSWORD",
+          "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
+        }
     ],
     "links": null,
     "workingDirectory": null,

--- a/modules/040-id-broker/test.tftest.hcl
+++ b/modules/040-id-broker/test.tftest.hcl
@@ -35,7 +35,6 @@ variables {
   help_center_url           = ""
   idp_name                  = ""
   mysql_host                = ""
-  mysql_pass                = ""
   mysql_user                = ""
   notification_email        = ""
   password_profile_url      = ""

--- a/modules/040-id-broker/test.tftest.hcl
+++ b/modules/040-id-broker/test.tftest.hcl
@@ -23,6 +23,7 @@ mock_provider "aws" {
 }
 
 mock_provider "cloudflare" {}
+
 variables {
   # required variables
   app_env                   = "test"
@@ -41,6 +42,7 @@ variables {
   rp_origins                = ""
   subdomain                 = "broker"
   support_email             = ""
+  task_execution_role_arn   = ""
   vpc_id                    = ""
 
   # either an internal or an external alb dns name and listener arn must be specified

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -689,7 +689,7 @@ variable "support_name" {
 
 variable "task_execution_role_arn" {
   description = <<-EOT
-    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    ARN of the IAM role that ECS will use to execute service tasks. It must have permission to read parameters from
     SSM Parameter Store.
   EOT
   type        = string

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -687,6 +687,14 @@ variable "support_name" {
   default     = "support"
 }
 
+variable "task_execution_role_arn" {
+  description = <<-EOT
+    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    SSM Parameter Store.
+  EOT
+  type        = string
+}
+
 variable "vpc_id" {
   description = "ID for VPC"
   type        = string

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -399,11 +399,6 @@ variable "mysql_host" {
   type        = string
 }
 
-variable "mysql_pass" {
-  description = "MySQL password for id-broker"
-  type        = string
-}
-
 variable "mysql_user" {
   description = "MySQL username for id-broker"
   type        = string

--- a/modules/050-pw-manager/README.md
+++ b/modules/050-pw-manager/README.md
@@ -42,6 +42,7 @@ module "pwmanager" {
   docker_image                        = data.terraform_remote_state.ecr.ecr_repo_pwapi
   ecs_cluster_id                      = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn                  = data.terraform_remote_state.core.ecsServiceRole_arn
+  task_execution_role_arn             = data.terraform_remote_state.core.task_execution_role_arn
   email_signature                     = data.terraform_remote_state.broker.email_signature
   extra_hosts                         = var.extra_hosts
   help_center_url                     = data.terraform_remote_state.broker.help_center_url

--- a/modules/050-pw-manager/README.md
+++ b/modules/050-pw-manager/README.md
@@ -53,7 +53,6 @@ module "pwmanager" {
   idp_name                            = var.idp_name
   memory                              = var.memory
   mysql_host                          = data.terraform_remote_state.database.rds_address
-  mysql_pass                          = data.terraform_remote_state.database.db_pwmanager_pass
   mysql_user                          = var.mysql_user
   password_rule_enablehibp            = var.password_rule_enablehibp
   password_rule_maxlength             = var.password_rule_maxlength

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -98,7 +98,6 @@ locals {
     idp_name                            = var.idp_name
     memory                              = var.memory
     mysql_host                          = var.mysql_host
-    mysql_password                      = var.mysql_pass
     mysql_user                          = var.mysql_user
     parameter_store_path                = local.parameter_store_path
     password_rule_alpha_and_numeric     = var.password_rule_alpha_and_numeric

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -130,6 +130,7 @@ module "ecsservice" {
   desired_count      = var.desired_count
   ecsServiceRole_arn = var.ecsServiceRole_arn
   task_role_arn      = module.ecs_role.role_arn
+  execution_role_arn = var.task_execution_role_arn
 
   load_balancer = [{
     target_group_arn = aws_alb_target_group.pwmanager.arn

--- a/modules/050-pw-manager/task-definition-api.json.tftpl
+++ b/modules/050-pw-manager/task-definition-api.json.tftpl
@@ -122,10 +122,6 @@
         "value": "${mysql_host}"
       },
       {
-        "name": "MYSQL_PASSWORD",
-        "value": "${mysql_password}"
-      },
-      {
         "name": "MYSQL_USER",
         "value": "${mysql_user}"
       },
@@ -197,6 +193,12 @@
         "name": "ZXCVBN_API_BASEURL",
         "value": "http://zxcvbn:3000"
       }
+    ],
+    "secrets": [
+        {
+          "name": "MYSQL_PASSWORD",
+          "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
+        }
     ],
     "links": [
       "zxcvbn"

--- a/modules/050-pw-manager/test.tftest.hcl
+++ b/modules/050-pw-manager/test.tftest.hcl
@@ -46,7 +46,6 @@ variables {
   idp_display_name          = ""
   idp_name                  = ""
   mysql_host                = ""
-  mysql_pass                = ""
   mysql_user                = ""
   recaptcha_key             = ""
   recaptcha_secret          = ""

--- a/modules/050-pw-manager/test.tftest.hcl
+++ b/modules/050-pw-manager/test.tftest.hcl
@@ -23,6 +23,7 @@ mock_provider "aws" {
 }
 
 mock_provider "cloudflare" {}
+
 variables {
   # required variables
   alb_dns_name              = ""
@@ -53,6 +54,7 @@ variables {
   support_name              = ""
   support_phone             = ""
   support_url               = ""
+  task_execution_role_arn   = ""
   ui_subdomain              = "profile"
   vpc_id                    = ""
 }

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -284,7 +284,7 @@ variable "support_url" {
 
 variable "task_execution_role_arn" {
   description = <<-EOT
-    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    ARN of the IAM role that ECS will use to execute service tasks. It must have permission to read parameters from
     SSM Parameter Store.
   EOT
   type        = string

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -202,11 +202,6 @@ variable "mysql_host" {
   type        = string
 }
 
-variable "mysql_pass" {
-  description = "MySQL password for id-broker"
-  type        = string
-}
-
 variable "mysql_user" {
   description = "MySQL username for id-broker"
   type        = string

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -282,6 +282,14 @@ variable "support_url" {
   type        = string
 }
 
+variable "task_execution_role_arn" {
+  description = <<-EOT
+    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    SSM Parameter Store.
+  EOT
+  type        = string
+}
+
 variable "ui_subdomain" {
   description = "Subdomain for PW UI"
   type        = string

--- a/modules/060-simplesamlphp/README.md
+++ b/modules/060-simplesamlphp/README.md
@@ -42,7 +42,6 @@ module "ssp" {
   db_name                      = var.db_ssp_name
   mysql_host                   = data.terraform_remote_state.database.rds_address
   mysql_user                   = var.db_ssp_user
-  mysql_pass                   = data.terraform_remote_state.database.db_ssp_pass
   profile_url                  = var.profile_url
   recaptcha_key                = var.recaptcha_key
   recaptcha_secret             = var.recaptcha_secret

--- a/modules/060-simplesamlphp/README.md
+++ b/modules/060-simplesamlphp/README.md
@@ -48,6 +48,7 @@ module "ssp" {
   remember_me_secret           = var.remember_me_secret
   ecs_cluster_id               = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn           = data.terraform_remote_state.core.ecsServiceRole_arn
+  task_execution_role_arn      = data.terraform_remote_state.core.task_execution_role_arn
   alb_dns_name                 = data.terraform_remote_state.cluster.alb_dns_name
   idp_name                     = var.idp_name
   theme_color_scheme           = var.theme_color_scheme

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -96,7 +96,6 @@ locals {
     logging_level               = var.logging_level
     mysql_database              = var.db_name
     mysql_host                  = var.mysql_host
-    mysql_password              = var.mysql_pass
     mysql_user                  = var.mysql_user
     parameter_store_path        = local.parameter_store_path
     port                        = var.enable_tls ? "443" : "80"

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -124,6 +124,7 @@ module "ecsservice" {
   desired_count      = var.desired_count
   ecsServiceRole_arn = var.ecsServiceRole_arn
   task_role_arn      = module.ecs_role.role_arn
+  execution_role_arn = var.task_execution_role_arn
 
   load_balancer = [{
     target_group_arn = aws_alb_target_group.ssp.arn

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -114,10 +114,6 @@
         "value": "${mysql_user}"
       },
       {
-        "name": "MYSQL_PASSWORD",
-        "value": "${mysql_password}"
-      },
-      {
         "name": "PARAMETER_STORE_PATH",
         "value": "${parameter_store_path}"
       },
@@ -157,6 +153,12 @@
         "name": "HELP_CENTER_URL",
         "value": "${help_center_url}"
       }
+    ],
+    "secrets": [
+        {
+          "name": "MYSQL_PASSWORD",
+          "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
+        }
     ],
     "links": null,
     "workingDirectory": null,

--- a/modules/060-simplesamlphp/test.tftest.hcl
+++ b/modules/060-simplesamlphp/test.tftest.hcl
@@ -39,7 +39,6 @@ variables {
   mfa_learn_more_url        = ""
   mfa_setup_url             = ""
   mysql_host                = ""
-  mysql_pass                = ""
   mysql_user                = ""
   password_change_url       = ""
   password_forgot_url       = ""

--- a/modules/060-simplesamlphp/test.tftest.hcl
+++ b/modules/060-simplesamlphp/test.tftest.hcl
@@ -47,6 +47,7 @@ variables {
   recaptcha_secret          = ""
   remember_me_secret        = ""
   subdomain                 = ""
+  task_execution_role_arn   = ""
   trusted_ip_addresses      = []
   vpc_id                    = ""
 }

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -260,7 +260,7 @@ variable "ssl_ca_base64" {
 
 variable "task_execution_role_arn" {
   description = <<-EOT
-    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    ARN of the IAM role that ECS will use to execute service tasks. It must have permission to read parameters from
     SSM Parameter Store.
   EOT
   type        = string

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -257,3 +257,11 @@ variable "ssl_ca_base64" {
   type        = string
   default     = ""
 }
+
+variable "task_execution_role_arn" {
+  description = <<-EOT
+    ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
+    SSM Parameter Store.
+  EOT
+  type        = string
+}

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -149,11 +149,6 @@ variable "mysql_user" {
   type        = string
 }
 
-variable "mysql_pass" {
-  description = "MySQL password for id-broker"
-  type        = string
-}
-
 variable "profile_url" {
   description = "URL of Password Manager profile page"
   type        = string

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -27,4 +27,5 @@ module "backup" {
   rclone_arguments                 = "--transfers 4 --checkers 8"
   b2_path                          = ""
   sync_schedule                    = null
+  task_execution_role_arn          = ""
 }

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -13,7 +13,6 @@ module "backup" {
   idp_name                         = ""
   memory                           = 1
   mysql_host                       = ""
-  mysql_pass                       = ""
   mysql_user                       = ""
   service_mode                     = ""
   enable_aws_backup                = true

--- a/test/040-id-broker.tf
+++ b/test/040-id-broker.tf
@@ -102,5 +102,6 @@ module "broker" {
   subject_for_welcome                        = ""
   support_email                              = ""
   support_name                               = ""
+  task_execution_role_arn                    = ""
   vpc_id                                     = ""
 }

--- a/test/040-id-broker.tf
+++ b/test/040-id-broker.tf
@@ -55,7 +55,6 @@ module "broker" {
   mfa_api_base_url                           = ""
   minimum_backup_codes_before_nag            = 1
   mysql_host                                 = ""
-  mysql_pass                                 = ""
   mysql_user                                 = ""
   notification_email                         = ""
   password_expiration_grace_period           = ""

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -45,6 +45,7 @@ module "pw" {
   support_name                        = ""
   support_phone                       = ""
   support_url                         = ""
+  task_execution_role_arn             = ""
   ui_subdomain                        = ""
   vpc_id                              = ""
 }

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -34,7 +34,6 @@ module "pw" {
   idp_name                            = ""
   memory                              = 1
   mysql_host                          = ""
-  mysql_pass                          = ""
   mysql_user                          = ""
   password_rule_enablehibp            = true
   password_rule_maxlength             = 1

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -41,6 +41,7 @@ module "ssp" {
   secret_salt                 = ""
   show_saml_errors            = true
   subdomain                   = ""
+  task_execution_role_arn     = ""
   theme_color_scheme          = ""
   trusted_ip_addresses        = [""]
   vpc_id                      = ""

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -31,7 +31,6 @@ module "ssp" {
   mfa_learn_more_url          = ""
   mfa_setup_url               = ""
   mysql_host                  = ""
-  mysql_pass                  = ""
   mysql_user                  = ""
   password_change_url         = ""
   password_forgot_url         = ""


### PR DESCRIPTION
[IDP-1717](https://support.gtis.sil.org/issue/IDP-1717) Move db-backup secrets to SSM Parameter Store
[IDP-1701](https://support.gtis.sil.org/issue/IDP-1701) move database passwords to Parameter Store

---

### Changed (BREAKING)
- Move the database password to SSM Parameter Store.
  - This requires a Parameter Store item to be created by the root level module.
  - It also combines the four service-specific passwords into one.
- Use a task role for the backup script to eliminate the need for a static access key.
- Use an execution role for the backup script to grant permission to read from SSM.