### PR TITLE
change the backup_user_name variable to backup_role_name

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -82,7 +82,7 @@ resource "aws_s3_bucket_public_access_block" "backup" {
  * Create role for putting backup files into the bucket
  */
 resource "aws_iam_role" "backup" {
-  name = var.backup_user_name == null ? "db-backup-${var.idp_name}-${var.app_env}" : var.backup_user_name
+  name = var.backup_role_name == null ? "${var.app_name}-${var.idp_name}-${var.app_env}" : var.backup_role_name
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -9,9 +9,10 @@ variable "app_name" {
   default     = "db-backup"
 }
 
-variable "backup_user_name" {
+variable "backup_role_name" {
   description = <<-EOT
-    Name of IAM user for S3 access. If not specified: `db-backup-{var.idp_name}-{var.app_env}`
+    Name of IAM role for S3 access. Typically used in a secondary region to avoid conflict with the role created
+    in the primary region. If not specified, the name will be `$${var.app_name}-$${var.idp_name}-$${var.app_env}.`
   EOT
   type        = string
   default     = null

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -295,6 +295,7 @@ module "email_service" {
   container_def_json = local.email_task_def
   desired_count      = 1
   task_role_arn      = module.ecs_role.role_arn
+  execution_role_arn = var.task_execution_role_arn
 }
 
 

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -3,7 +3,7 @@ module "backup" {
 
   app_env                          = ""
   app_name                         = ""
-  backup_user_name                 = ""
+  backup_role_name                 = ""
   cloudwatch_log_group_name        = ""
   cpu                              = 1
   event_schedule                   = ""


### PR DESCRIPTION
[IDP-1717](https://support.gtis.sil.org/issue/IDP-1717) Move db-backup secrets to SSM Parameter Store

---


### Changed (BREAKING)
- Changed the `backup_user_name` variable to `backup_role_name`.
- Changed the default backup role name to start with `var.app_name` (which defaults to "db-backup") instead of the fixed string "db-backup" to give an alternate means to deconflict across regions.

### Fixed 
- Add the task execution role to the email service in addition to the web service.