### PR TITLE
make auth_saml_spPrivateKey a parameter in SSM

### DIFF
--- a/modules/050-pw-manager/README.md
+++ b/modules/050-pw-manager/README.md
@@ -32,7 +32,6 @@ module "pwmanager" {
   auth_saml_requireEncryptedAssertion = var.auth_saml_requireEncryptedAssertion
   auth_saml_signRequest               = var.auth_saml_signRequest
   auth_saml_spCertificate             = var.auth_saml_spCertificate
-  auth_saml_spPrivateKey              = var.auth_saml_spPrivateKey
   cloudflare_domain                   = var.cloudflare_domain
   cloudwatch_log_group_name           = var.cloudwatch_log_group_name
   code_length                         = var.code_length

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -238,6 +238,17 @@ resource "aws_iam_policy" "cd" {
   })
 }
 
+# Store SAML SP private key in Parameter Store as a SecureString but only if a value is given. Otherwise, the
+# SSM parameter should be created and managed manually.
+resource "aws_ssm_parameter" "auth_saml_sp_private_key" {
+  count = var.auth_saml_spPrivateKey != null ? 1 : 0
+
+  name        = "${local.parameter_store_path}AUTH_SAML_spPrivateKey"
+  type        = "SecureString"
+  value       = var.auth_saml_spPrivateKey
+  description = "Value set by Terraform -- do not change manually."
+}
+
 /*
  * AWS data
  */

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -241,7 +241,7 @@ resource "aws_iam_policy" "cd" {
 # Store SAML SP private key in Parameter Store as a SecureString but only if a value is given. Otherwise, the
 # SSM parameter should be created and managed manually.
 resource "aws_ssm_parameter" "auth_saml_sp_private_key" {
-  count = var.auth_saml_spPrivateKey != null ? 1 : 0
+  count = var.auth_saml_spPrivateKey != null && var.auth_saml_spPrivateKey != "" ? 1 : 0
 
   name        = "${local.parameter_store_path}AUTH_SAML_spPrivateKey"
   type        = "SecureString"

--- a/modules/050-pw-manager/task-definition-api.json.tftpl
+++ b/modules/050-pw-manager/task-definition-api.json.tftpl
@@ -62,10 +62,6 @@
         "value": "${auth_saml_spCertificate}"
       },
       {
-        "name": "AUTH_SAML_spPrivateKey",
-        "value": "${auth_saml_spPrivateKey}"
-      },
-      {
         "name": "AUTH_SAML_entityId",
         "value": "${auth_saml_entityId}"
       },
@@ -195,6 +191,10 @@
       }
     ],
     "secrets": [
+        {
+          "name": "AUTH_SAML_spPrivateKey",
+          "valueFrom": "${parameter_store_path}AUTH_SAML_spPrivateKey"
+        },
         {
           "name": "MYSQL_PASSWORD",
           "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"

--- a/modules/050-pw-manager/test.tftest.hcl
+++ b/modules/050-pw-manager/test.tftest.hcl
@@ -32,7 +32,6 @@ variables {
   app_env                   = "test"
   auth_saml_idpCertificate  = ""
   auth_saml_spCertificate   = ""
-  auth_saml_spPrivateKey    = ""
   cloudflare_domain         = "example.com"
   cloudwatch_log_group_name = ""
   db_name                   = ""

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -70,8 +70,13 @@ variable "auth_saml_spCertificate" {
 }
 
 variable "auth_saml_spPrivateKey" {
-  description = "Private cert data for this SP"
+  description = <<-EOT
+     Private cert data for this SP. If provided, it will be stored in SSM Parameter Store as a SecureString given.
+     Otherwise, the SSM parameter /idp-$${var.idp_name}/AUTH_SAML_spPrivateKey should be created and managed manually.
+  EOT
   type        = string
+  default     = null
+  sensitive   = true
 }
 
 variable "cduser_username" {

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -12,7 +12,6 @@ module "pw" {
   auth_saml_requireEncryptedAssertion = true
   auth_saml_signRequest               = true
   auth_saml_spCertificate             = ""
-  auth_saml_spPrivateKey              = ""
   cloudflare_domain                   = ""
   cloudwatch_log_group_name           = ""
   code_length                         = 1


### PR DESCRIPTION
[IDP-1974](https://support.gtis.sil.org/issue/IDP-1974) Remove auth_saml_spPrivateKey variable

---

### Changed
- Move `AUTH_SAML_spPrivateKey` to SSM Parameter Store, either as a Terraform-managed resource or a manual one.