### PR TITLE
Move simplesamlphp secrets into SSM Parameter Store

### DIFF
--- a/modules/050-pw-manager/README.md
+++ b/modules/050-pw-manager/README.md
@@ -58,8 +58,6 @@ module "pwmanager" {
   password_rule_maxlength             = var.password_rule_maxlength
   password_rule_minlength             = var.password_rule_minlength
   password_rule_minscore              = var.password_rule_minscore
-  recaptcha_key                       = var.recaptcha_key
-  recaptcha_secret                    = var.recaptcha_secret
   support_email                       = data.terraform_remote_state.broker.support_email
   support_name                        = data.terraform_remote_state.broker.support_name
   support_phone                       = var.support_phone

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -106,8 +106,6 @@ locals {
     password_rule_minlength             = var.password_rule_minlength
     password_rule_minscore              = var.password_rule_minscore
     port                                = var.enable_tls ? "443" : "80"
-    recaptcha_secret_key                = var.recaptcha_secret
-    recaptcha_site_key                  = var.recaptcha_key
     sentry_dsn                          = var.sentry_dsn
     ssl_ca_base64                       = var.ssl_ca_base64
     support_email                       = var.support_email

--- a/modules/050-pw-manager/task-definition-api.json.tftpl
+++ b/modules/050-pw-manager/task-definition-api.json.tftpl
@@ -146,14 +146,6 @@
         "value": "${password_rule_alpha_and_numeric}"
       },
       {
-        "name": "RECAPTCHA_SECRET_KEY",
-        "value": "${recaptcha_secret_key}"
-      },
-      {
-        "name": "RECAPTCHA_SITE_KEY",
-        "value": "${recaptcha_site_key}"
-      },
-      {
         "name": "SENTRY_DSN",
         "value": "${sentry_dsn}"
       },

--- a/modules/050-pw-manager/test.tftest.hcl
+++ b/modules/050-pw-manager/test.tftest.hcl
@@ -47,8 +47,6 @@ variables {
   idp_name                  = ""
   mysql_host                = ""
   mysql_user                = ""
-  recaptcha_key             = ""
-  recaptcha_secret          = ""
   support_email             = ""
   support_name              = ""
   support_phone             = ""

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -242,16 +242,6 @@ variable "password_rule_minscore" {
   default     = 3
 }
 
-variable "recaptcha_key" {
-  description = "Recaptcha site key"
-  type        = string
-}
-
-variable "recaptcha_secret" {
-  description = "Recaptcha secret"
-  type        = string
-}
-
 variable "sentry_dsn" {
   description = <<-EOT
     Sentry DSN for error logging and alerting. Obtain from Sentry dashboard: Settings - Projects - (project) -

--- a/modules/060-simplesamlphp/README.md
+++ b/modules/060-simplesamlphp/README.md
@@ -43,7 +43,6 @@ module "ssp" {
   mysql_host                   = data.terraform_remote_state.database.rds_address
   mysql_user                   = var.db_ssp_user
   profile_url                  = var.profile_url
-  remember_me_secret           = var.remember_me_secret
   ecs_cluster_id               = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn           = data.terraform_remote_state.core.ecsServiceRole_arn
   task_execution_role_arn      = data.terraform_remote_state.core.task_execution_role_arn

--- a/modules/060-simplesamlphp/README.md
+++ b/modules/060-simplesamlphp/README.md
@@ -43,8 +43,6 @@ module "ssp" {
   mysql_host                   = data.terraform_remote_state.database.rds_address
   mysql_user                   = var.db_ssp_user
   profile_url                  = var.profile_url
-  recaptcha_key                = var.recaptcha_key
-  recaptcha_secret             = var.recaptcha_secret
   remember_me_secret           = var.remember_me_secret
   ecs_cluster_id               = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn           = data.terraform_remote_state.core.ecsServiceRole_arn

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -100,7 +100,6 @@ locals {
     parameter_store_path        = local.parameter_store_path
     port                        = var.enable_tls ? "443" : "80"
     profile_url                 = var.profile_url
-    remember_me_secret          = var.remember_me_secret
     secret_salt                 = local.secret_salt
     show_saml_errors            = var.show_saml_errors
     ssl_ca_base64               = var.ssl_ca_base64

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -75,7 +75,7 @@ locals {
     cpu                         = var.cpu
     admin_email                 = var.admin_email
     admin_name                  = var.admin_name
-    admin_pass                  = random_id.admin_pass.hex
+    admin_pass_arn              = aws_ssm_parameter.admin_pass.arn
     app_env                     = var.app_env
     app_name                    = var.app_name
     aws_region                  = local.aws_region
@@ -230,6 +230,13 @@ resource "aws_iam_policy" "cd" {
       },
     ]
   })
+}
+
+resource "aws_ssm_parameter" "admin_pass" {
+  name        = "${local.parameter_store_path}ADMIN_PASS"
+  type        = "SecureString"
+  value       = random_id.admin_pass.hex
+  description = "Value set by Terraform -- do not change manually."
 }
 
 /*

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -100,8 +100,6 @@ locals {
     parameter_store_path        = local.parameter_store_path
     port                        = var.enable_tls ? "443" : "80"
     profile_url                 = var.profile_url
-    recaptcha_key               = var.recaptcha_key
-    recaptcha_secret            = var.recaptcha_secret
     remember_me_secret          = var.remember_me_secret
     secret_salt                 = local.secret_salt
     show_saml_errors            = var.show_saml_errors

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -50,8 +50,9 @@ resource "aws_alb_listener_rule" "ssp" {
 /*
  * Create ECS service
  */
-resource "random_id" "admin_pass" {
-  byte_length = 32
+
+resource "random_password" "admin_pass" {
+  length = 96
 }
 
 resource "random_id" "secretsalt" {
@@ -232,7 +233,7 @@ resource "aws_iam_policy" "cd" {
 resource "aws_ssm_parameter" "admin_pass" {
   name        = "${local.parameter_store_path}ADMIN_PASS"
   type        = "SecureString"
-  value       = random_id.admin_pass.hex
+  value       = random_password.admin_pass.result
   description = "Value set by Terraform -- do not change manually."
 }
 

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -100,7 +100,7 @@ locals {
     parameter_store_path        = local.parameter_store_path
     port                        = var.enable_tls ? "443" : "80"
     profile_url                 = var.profile_url
-    secret_salt                 = local.secret_salt
+    secret_salt_arn             = aws_ssm_parameter.secret_salt.arn
     show_saml_errors            = var.show_saml_errors
     ssl_ca_base64               = var.ssl_ca_base64
     theme_color_scheme          = var.theme_color_scheme
@@ -233,6 +233,13 @@ resource "aws_ssm_parameter" "admin_pass" {
   name        = "${local.parameter_store_path}ADMIN_PASS"
   type        = "SecureString"
   value       = random_id.admin_pass.hex
+  description = "Value set by Terraform -- do not change manually."
+}
+
+resource "aws_ssm_parameter" "secret_salt" {
+  name        = "${local.parameter_store_path}SECRET_SALT"
+  type        = "SecureString"
+  value       = local.secret_salt
   description = "Value set by Terraform -- do not change manually."
 }
 

--- a/modules/060-simplesamlphp/outputs.tf
+++ b/modules/060-simplesamlphp/outputs.tf
@@ -1,6 +1,6 @@
 output "admin_pass" {
   description = "SSP Admin password"
-  value       = random_id.admin_pass.hex
+  value       = random_password.admin_pass.result
   sensitive   = true
 }
 

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -118,10 +118,6 @@
         "value":  "${profile_url}"
       },
       {
-        "name": "REMEMBER_ME_SECRET",
-        "value": "${remember_me_secret}"
-      },
-      {
         "name": "SSL_CA_BASE64",
         "value": "${ssl_ca_base64}"
       },

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -34,10 +34,6 @@
         "value": "${admin_name}"
       },
       {
-        "name": "ADMIN_PASS",
-        "value": "${admin_pass}"
-      },
-      {
         "name": "BASE_URL_PATH",
         "value": "${base_url}"
       },
@@ -155,6 +151,10 @@
       }
     ],
     "secrets": [
+        {
+          "name": "ADMIN_PASS",
+          "valueFrom": "${admin_pass_arn}"
+        },
         {
           "name": "MYSQL_PASSWORD",
           "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -118,14 +118,6 @@
         "value":  "${profile_url}"
       },
       {
-        "name": "RECAPTCHA_SITE_KEY",
-        "value": "${recaptcha_key}"
-      },
-      {
-        "name": "RECAPTCHA_SECRET",
-        "value": "${recaptcha_secret}"
-      },
-      {
         "name": "REMEMBER_ME_SECRET",
         "value": "${remember_me_secret}"
       },

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -42,10 +42,6 @@
         "value": "${enable_debug}"
       },
       {
-        "name": "SECRET_SALT",
-        "value": "${secret_salt}"
-      },
-      {
         "name": "SESSION_STORE_TYPE",
         "value": "sql"
       },
@@ -146,6 +142,10 @@
         {
           "name": "MYSQL_PASSWORD",
           "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
+        },
+        {
+          "name": "SECRET_SALT",
+          "valueFrom": "${secret_salt_arn}"
         }
     ],
     "links": null,

--- a/modules/060-simplesamlphp/test.tftest.hcl
+++ b/modules/060-simplesamlphp/test.tftest.hcl
@@ -43,8 +43,6 @@ variables {
   password_change_url       = ""
   password_forgot_url       = ""
   profile_url               = ""
-  recaptcha_key             = ""
-  recaptcha_secret          = ""
   remember_me_secret        = ""
   subdomain                 = ""
   task_execution_role_arn   = ""

--- a/modules/060-simplesamlphp/test.tftest.hcl
+++ b/modules/060-simplesamlphp/test.tftest.hcl
@@ -43,7 +43,6 @@ variables {
   password_change_url       = ""
   password_forgot_url       = ""
   profile_url               = ""
-  remember_me_secret        = ""
   subdomain                 = ""
   task_execution_role_arn   = ""
   trusted_ip_addresses      = []

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -154,16 +154,6 @@ variable "profile_url" {
   type        = string
 }
 
-variable "recaptcha_key" {
-  description = "Recaptcha site key"
-  type        = string
-}
-
-variable "recaptcha_secret" {
-  description = "Recaptcha secret"
-  type        = string
-}
-
 variable "remember_me_secret" {
   description = "Secret key used in MFA remember me cookie generation"
   type        = string

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -154,11 +154,6 @@ variable "profile_url" {
   type        = string
 }
 
-variable "remember_me_secret" {
-  description = "Secret key used in MFA remember me cookie generation"
-  type        = string
-}
-
 variable "ecs_cluster_id" {
   description = "ID for ECS Cluster"
   type        = string

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -8,6 +8,7 @@ variable "secret_salt" {
   EOT
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "memory" {

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -38,8 +38,6 @@ module "pw" {
   password_rule_maxlength             = 1
   password_rule_minlength             = 1
   password_rule_minscore              = 1
-  recaptcha_key                       = ""
-  recaptcha_secret                    = ""
   support_email                       = ""
   support_name                        = ""
   support_phone                       = ""

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -35,8 +35,6 @@ module "ssp" {
   password_change_url         = ""
   password_forgot_url         = ""
   profile_url                 = ""
-  recaptcha_key               = ""
-  recaptcha_secret            = ""
   remember_me_secret          = ""
   secret_salt                 = ""
   show_saml_errors            = true

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -35,7 +35,6 @@ module "ssp" {
   password_change_url         = ""
   password_forgot_url         = ""
   profile_url                 = ""
-  remember_me_secret          = ""
   secret_salt                 = ""
   show_saml_errors            = true
   subdomain                   = ""


### PR DESCRIPTION
[IDP-1977](https://support.gtis.sil.org/issue/IDP-1977) Move ssp-base secrets to Parameter Store

---

### Changed
- Moved ADMIN_PASS into SSM Parameter Store

### Removed
- Removed `recaptcha_key`, `recaptcha_secret`, and `remember_me_secret` variables since they have already been moved to SSM.