### PR TITLE
use SSM for id-broker access token

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,14 +26,4 @@ jobs:
           terraform_version: "1.7.5"
 
       - name: Test
-        run: |
-          terraform -chdir=modules/010-cluster/ init
-          terraform -chdir=modules/010-cluster/ test -verbose
-          terraform -chdir=modules/032-db-backup/ init
-          terraform -chdir=modules/032-db-backup/ test -verbose
-          terraform -chdir=modules/040-id-broker/ init
-          terraform -chdir=modules/040-id-broker/ test -verbose
-          terraform -chdir=modules/050-pw-manager/ init
-          terraform -chdir=modules/050-pw-manager/ test -verbose
-          terraform -chdir=modules/060-simplesamlphp/ init
-          terraform -chdir=modules/060-simplesamlphp/ test -verbose
+        run: ./test.sh

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -51,39 +51,8 @@ resource "aws_alb_listener_rule" "broker" {
   }
 }
 
-/*
- * Generate access tokens for consuming apps
- */
-resource "random_id" "access_token_pwmanager" {
-  byte_length = 16
-}
-
-resource "random_id" "access_token_search" {
-  byte_length = 16
-}
-
-resource "random_id" "access_token_ssp" {
-  byte_length = 16
-}
-
-resource "random_id" "access_token_idsync" {
-  byte_length = 16
-}
-
-resource "random_id" "access_token_pwmanager_b" {
-  byte_length = 32
-}
-
-resource "random_id" "access_token_search_b" {
-  byte_length = 32
-}
-
-resource "random_id" "access_token_ssp_b" {
-  byte_length = 32
-}
-
-resource "random_id" "access_token_idsync_b" {
-  byte_length = 32
+data "aws_ssm_parameter" "access_key" {
+  name = "${local.parameter_store_path}ID_BROKER_ACCESS_TOKEN"
 }
 
 /*
@@ -96,22 +65,11 @@ locals {
       value = v
     })]
   )
-  api_access_keys = join(",", [
-    random_id.access_token_pwmanager.hex,
-    random_id.access_token_search.hex,
-    random_id.access_token_ssp.hex,
-    random_id.access_token_idsync.hex,
-    random_id.access_token_pwmanager_b.hex,
-    random_id.access_token_search_b.hex,
-    random_id.access_token_ssp_b.hex,
-    random_id.access_token_idsync_b.hex,
-  ])
 
   subdomain_with_region = "${var.subdomain}-${local.aws_region}"
 
   task_def = templatefile("${path.module}/task-definition.json.tftpl", local.task_def_vars)
   task_def_vars = {
-    api_access_keys                            = local.api_access_keys
     abandoned_user_abandoned_period            = var.abandoned_user_abandoned_period
     abandoned_user_best_practice_url           = var.abandoned_user_best_practice_url
     abandoned_user_deactivate_instructions_url = var.abandoned_user_deactivate_instructions_url

--- a/modules/040-id-broker/outputs.tf
+++ b/modules/040-id-broker/outputs.tf
@@ -8,24 +8,10 @@ output "public_dns_value" {
   value       = cloudflare_record.brokerdns.hostname
 }
 
-output "access_token_pwmanager" {
-  description = "Access token for PW Manager to use in API calls to id-broker"
-  value       = var.output_alternate_tokens ? random_id.access_token_pwmanager_b.hex : random_id.access_token_pwmanager.hex
-}
-
 output "access_token_search" {
   description = "Access token for search lambda to use in API calls to id-broker"
-  value       = var.output_alternate_tokens ? random_id.access_token_search_b.hex : random_id.access_token_search.hex
-}
-
-output "access_token_ssp" {
-  description = "Access token for simpleSAMLphp to use in API calls to id-broker"
-  value       = var.output_alternate_tokens ? random_id.access_token_ssp_b.hex : random_id.access_token_ssp.hex
-}
-
-output "access_token_idsync" {
-  description = "Access token for id-sync to use in API calls to id-broker"
-  value       = var.output_alternate_tokens ? random_id.access_token_idsync_b.hex : random_id.access_token_idsync.hex
+  value       = data.aws_ssm_parameter.access_key.value
+  sensitive   = true
 }
 
 output "help_center_url" {

--- a/modules/040-id-broker/outputs.tf
+++ b/modules/040-id-broker/outputs.tf
@@ -9,7 +9,7 @@ output "public_dns_value" {
 }
 
 output "access_token_search" {
-  description = "Access token for search lambda to use in API calls to id-broker"
+  description = "Access token for search lambda to use in API calls to id-broker. DEPRECATED: broker search is archived."
   value       = data.aws_ssm_parameter.access_key.value
   sensitive   = true
 }

--- a/modules/040-id-broker/task-definition.json.tftpl
+++ b/modules/040-id-broker/task-definition.json.tftpl
@@ -37,10 +37,6 @@
         "value": "${abandoned_user_deactivate_instructions_url}"
       },
       {
-        "name": "API_ACCESS_KEYS",
-        "value": "${api_access_keys}"
-      },
-      {
         "name": "APP_ENV",
         "value": "${app_env}"
       },
@@ -403,6 +399,10 @@
       }
     ],
     "secrets": [
+        {
+          "name": "API_ACCESS_KEYS",
+          "valueFrom": "${parameter_store_path}API_ACCESS_KEYS"
+        },
         {
           "name": "MYSQL_PASSWORD",
           "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -409,12 +409,6 @@ variable "notification_email" {
   type        = string
 }
 
-variable "output_alternate_tokens" {
-  description = "Output alternate tokens for client services. Used for token rotation."
-  type        = bool
-  default     = false
-}
-
 variable "password_expiration_grace_period" {
   description = "Grace period after `password_lifespan` after which the account will be locked."
   type        = string

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -90,7 +90,6 @@ locals {
     email_signature                     = var.email_signature
     extra_hosts                         = var.extra_hosts
     help_center_url                     = var.help_center_url
-    id_broker_access_token              = var.id_broker_access_token
     id_broker_assertValidBrokerIp       = var.id_broker_assertValidBrokerIp
     id_broker_base_uri                  = var.id_broker_base_uri
     id_broker_validIpRanges             = join(",", var.id_broker_validIpRanges)

--- a/modules/050-pw-manager/task-definition-api.json.tftpl
+++ b/modules/050-pw-manager/task-definition-api.json.tftpl
@@ -185,7 +185,7 @@
         },
         {
           "name": "ID_BROKER_accessToken",
-          "value": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
+          "valueFrom": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
         },
         {
           "name": "MYSQL_PASSWORD",

--- a/modules/050-pw-manager/task-definition-api.json.tftpl
+++ b/modules/050-pw-manager/task-definition-api.json.tftpl
@@ -86,10 +86,6 @@
         "value": "${help_center_url}"
       },
       {
-        "name": "ID_BROKER_accessToken",
-        "value": "${id_broker_access_token}"
-      },
-      {
         "name": "ID_BROKER_baseUrl",
         "value": "${id_broker_base_uri}"
       },
@@ -186,6 +182,10 @@
         {
           "name": "AUTH_SAML_spPrivateKey",
           "valueFrom": "${parameter_store_path}AUTH_SAML_spPrivateKey"
+        },
+        {
+          "name": "ID_BROKER_accessToken",
+          "value": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
         },
         {
           "name": "MYSQL_PASSWORD",

--- a/modules/050-pw-manager/test.tftest.hcl
+++ b/modules/050-pw-manager/test.tftest.hcl
@@ -40,7 +40,6 @@ variables {
   ecs_cluster_id            = ""
   email_signature           = ""
   help_center_url           = ""
-  id_broker_access_token    = ""
   id_broker_base_uri        = ""
   id_broker_validIpRanges   = [""]
   idp_display_name          = ""

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -165,11 +165,6 @@ variable "help_center_url" {
   type = string
 }
 
-variable "id_broker_access_token" {
-  description = "Access token for calling id-broker"
-  type        = string
-}
-
 variable "id_broker_assertValidBrokerIp" {
   description = "Whether to assert IP address for ID Broker API is trusted"
   type        = bool

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -87,7 +87,6 @@ locals {
     password_change_url         = var.password_change_url
     password_forgot_url         = var.password_forgot_url
     hub_mode                    = var.hub_mode
-    id_broker_access_token      = var.id_broker_access_token
     id_broker_assert_valid_ip   = var.id_broker_assert_valid_ip
     id_broker_base_uri          = var.id_broker_base_uri
     id_broker_trusted_ip_ranges = join(",", var.id_broker_trusted_ip_ranges)

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -66,10 +66,6 @@
         "value": "${hub_mode}"
       },
       {
-        "name": "ID_BROKER_ACCESS_TOKEN",
-        "value": "${id_broker_access_token}"
-      },
-      {
         "name": "ID_BROKER_ASSERT_VALID_IP",
         "value": "${id_broker_assert_valid_ip}"
       },
@@ -138,6 +134,10 @@
         {
           "name": "ADMIN_PASS",
           "valueFrom": "${admin_pass_arn}"
+        },
+        {
+          "name": "ID_BROKER_ACCESS_TOKEN",
+          "value": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
         },
         {
           "name": "MYSQL_PASSWORD",

--- a/modules/060-simplesamlphp/task-definition.json.tftpl
+++ b/modules/060-simplesamlphp/task-definition.json.tftpl
@@ -137,7 +137,7 @@
         },
         {
           "name": "ID_BROKER_ACCESS_TOKEN",
-          "value": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
+          "valueFrom": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
         },
         {
           "name": "MYSQL_PASSWORD",

--- a/modules/060-simplesamlphp/test.tftest.hcl
+++ b/modules/060-simplesamlphp/test.tftest.hcl
@@ -33,7 +33,6 @@ variables {
   ecsServiceRole_arn        = ""
   ecs_cluster_id            = ""
   help_center_url           = ""
-  id_broker_access_token    = ""
   id_broker_base_uri        = ""
   idp_name                  = ""
   mfa_learn_more_url        = ""

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -95,11 +95,6 @@ variable "hub_mode" {
   default     = false
 }
 
-variable "id_broker_access_token" {
-  description = "Access token for calling id-broker"
-  type        = string
-}
-
 variable "id_broker_assert_valid_ip" {
   description = "Whether to assert valid ip for calling id-broker"
   type        = bool

--- a/modules/070-id-sync/main.tf
+++ b/modules/070-id-sync/main.tf
@@ -19,7 +19,6 @@ locals {
     aws_region                   = local.aws_region
     cloudwatch_log_group_name    = var.cloudwatch_log_group_name
     docker_image                 = var.docker_image
-    id_broker_access_token       = var.id_broker_access_token
     id_broker_adapter            = var.id_broker_adapter
     id_broker_assertValidIp      = var.id_broker_assertValidIp
     id_broker_base_url           = var.id_broker_base_url

--- a/modules/070-id-sync/task-definition.json.tftpl
+++ b/modules/070-id-sync/task-definition.json.tftpl
@@ -23,10 +23,6 @@
         "value": "${app_env}"
       },
       {
-        "name": "ID_BROKER_CONFIG_accessToken",
-        "value": "${id_broker_access_token}"
-      },
-      {
         "name": "ID_BROKER_ADAPTER",
         "value": "${id_broker_adapter}"
       },
@@ -95,6 +91,12 @@
         "value": "${heartbeat_method}"
       }
       ${id_store_config}
+    ],
+    "secrets": [
+        {
+          "name": "ID_BROKER_CONFIG_accessToken",
+          "value": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
+        }
     ],
     "links": null,
     "workingDirectory": null,

--- a/modules/070-id-sync/task-definition.json.tftpl
+++ b/modules/070-id-sync/task-definition.json.tftpl
@@ -95,7 +95,7 @@
     "secrets": [
         {
           "name": "ID_BROKER_CONFIG_accessToken",
-          "value": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
+          "valueFrom": "${parameter_store_path}ID_BROKER_ACCESS_TOKEN"
         }
     ],
     "links": null,

--- a/modules/070-id-sync/test.tftest.hcl
+++ b/modules/070-id-sync/test.tftest.hcl
@@ -1,0 +1,26 @@
+mock_provider "aws" {
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111111111111:role/test-role"
+    }
+  }
+  mock_resource "aws_ecs_task_definition" {
+    defaults = {
+      arn = "arn:aws:ecs:us-east-1:111111111111:task-definition/test-task-definition:1"
+    }
+  }
+}
+
+variables {
+  app_env                   = ""
+  cloudwatch_log_group_name = ""
+  docker_image              = ""
+  id_broker_base_url        = ""
+  id_broker_trustedIpRanges = []
+  id_store_adapter          = ""
+  id_store_config           = {}
+  idp_name                  = ""
+  ecs_cluster_id            = ""
+}
+
+run "test" {}

--- a/modules/070-id-sync/variables.tf
+++ b/modules/070-id-sync/variables.tf
@@ -34,11 +34,6 @@ variable "docker_image" {
   type        = string
 }
 
-variable "id_broker_access_token" {
-  description = "Access token for calling id-broker"
-  type        = string
-}
-
 variable "id_broker_adapter" {
   description = "Which ID Sync adapter to use"
   type        = string

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "::group:: 010-cluster"
+terraform -chdir=modules/010-cluster/ init
+terraform -chdir=modules/010-cluster/ test -verbose
+echo "::endgroup::"
+
+echo "::group:: 032-db-backup"
+terraform -chdir=modules/032-db-backup/ init
+terraform -chdir=modules/032-db-backup/ test -verbose
+echo "::endgroup::"
+
+echo "::group:: 040-id-broker"
+terraform -chdir=modules/040-id-broker/ init
+terraform -chdir=modules/040-id-broker/ test -verbose
+echo "::endgroup::"
+
+echo "::group:: 050-pw-manager"
+terraform -chdir=modules/050-pw-manager/ init
+terraform -chdir=modules/050-pw-manager/ test -verbose
+echo "::endgroup::"
+
+echo "::group:: 060-simplesamlphp"
+terraform -chdir=modules/060-simplesamlphp/ init
+terraform -chdir=modules/060-simplesamlphp/ test -verbose
+echo "::endgroup::"
+
+echo "::group:: 070-id-sync"
+terraform -chdir=modules/070-id-sync/ init
+terraform -chdir=modules/070-id-sync/ test -verbose
+echo "::endgroup::"

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -25,7 +25,6 @@ module "pw" {
   email_signature                     = ""
   extra_hosts                         = ""
   help_center_url                     = ""
-  id_broker_access_token              = ""
   id_broker_assertValidBrokerIp       = true
   id_broker_base_uri                  = ""
   id_broker_validIpRanges             = [""]

--- a/test/060-simplesamlphp.tf
+++ b/test/060-simplesamlphp.tf
@@ -21,7 +21,6 @@ module "ssp" {
   enable_debug                = true
   help_center_url             = ""
   hub_mode                    = true
-  id_broker_access_token      = ""
   id_broker_assert_valid_ip   = true
   id_broker_base_uri          = ""
   id_broker_trusted_ip_ranges = [""]

--- a/test/070-id-sync.tf
+++ b/test/070-id-sync.tf
@@ -12,7 +12,6 @@ module "sync" {
   enable_new_user_notification = true
   enable_sync                  = true
   event_schedule               = ""
-  id_broker_access_token       = ""
   id_broker_adapter            = ""
   id_broker_assertValidIp      = true
   id_broker_base_url           = ""


### PR DESCRIPTION
[IDP-1702](https://support.gtis.sil.org/issue/IDP-1702) move id-broker api_access_keys to parameter store
[IDP-1976](https://support.gtis.sil.org/issue/IDP-1976) Move id-broker access tokens to Parameter Store

---

### Added
- Added test file to the 070-id-sync module.
- Added test script with GitHub workflow commands to group each module's test output.

### Changed (BREAKING)
- Reference SSM Parameter Store for the id-broker access token.
- Use one token for all services. Rationale:
  - Access is not different with each token, so blast radius is not controlled.
  - Credential rotation cannot be done for one token separate from the others.
  - Logging doesn't reference the token used for access, limiting usefulness for audit.
  - There are no plans to expand this capability, but there are plans to reduce complexity.

### Removed
- Removed Terraform-generated tokens. Future tokens should be generated externally and stored in SSM as parameter `ID_BROKER_ACCESS_TOKEN` with path /idp-_idp_name_/.
