### PR TITLE
add the task execution role ARN to id-sync

### DIFF
--- a/modules/070-id-sync/main.tf
+++ b/modules/070-id-sync/main.tf
@@ -65,6 +65,7 @@ resource "aws_ecs_task_definition" "cron_td" {
   container_definitions = local.task_def
   network_mode          = "bridge"
   task_role_arn         = module.ecs_role.role_arn
+  execution_role_arn    = var.task_execution_role_arn
 }
 
 /*

--- a/modules/070-id-sync/test.tftest.hcl
+++ b/modules/070-id-sync/test.tftest.hcl
@@ -21,6 +21,7 @@ variables {
   id_store_config           = {}
   idp_name                  = ""
   ecs_cluster_id            = ""
+  task_execution_role_arn   = ""
 }
 
 run "test" {}

--- a/modules/070-id-sync/variables.tf
+++ b/modules/070-id-sync/variables.tf
@@ -147,3 +147,11 @@ variable "heartbeat_method" {
   type        = string
   default     = "POST"
 }
+
+variable "task_execution_role_arn" {
+  description = <<-EOT
+    ARN of the IAM role that ECS will use to execute service tasks. It must have permission to read parameters from
+    SSM Parameter Store.
+  EOT
+  type        = string
+}

--- a/test/070-id-sync.tf
+++ b/test/070-id-sync.tf
@@ -23,4 +23,5 @@ module "sync" {
   memory                       = 1
   notifier_email_to            = ""
   sync_safety_cutoff           = 0.9
+  task_execution_role_arn      = ""
 }


### PR DESCRIPTION
[IDP-1976](https://support.gtis.sil.org/issue/IDP-1976) Move id-broker access tokens to Parameter Store

---

### Fixed
- Added the task execution role ARN to the id-sync task definition. This should have been added in #342.
