### PR TITLE
require the auth_saml_spPrivateKey be added directly to SSM

### DIFF
--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -80,7 +80,6 @@ locals {
     auth_saml_signRequest               = var.auth_saml_signRequest
     auth_saml_sloUrl                    = "${var.auth_saml_idp_url}/saml2/idp/SingleLogoutService.php"
     auth_saml_spCertificate             = var.auth_saml_spCertificate
-    auth_saml_spPrivateKey              = var.auth_saml_spPrivateKey
     auth_saml_ssoUrl                    = "${var.auth_saml_idp_url}/saml2/idp/SSOService.php"
     cmd                                 = "/data/run.sh"
     code_length                         = var.code_length
@@ -230,17 +229,6 @@ resource "aws_ssm_parameter" "access_token_hash_key" {
   name        = "${local.parameter_store_path}ACCESS_TOKEN_HASH_KEY"
   type        = "SecureString"
   value       = random_id.access_token_hash.hex
-  description = "Value set by Terraform -- do not change manually."
-}
-
-# Store SAML SP private key in Parameter Store as a SecureString but only if a value is given. Otherwise, the
-# SSM parameter should be created and managed manually.
-resource "aws_ssm_parameter" "auth_saml_sp_private_key" {
-  count = var.auth_saml_spPrivateKey != null && var.auth_saml_spPrivateKey != "" ? 1 : 0
-
-  name        = "${local.parameter_store_path}AUTH_SAML_spPrivateKey"
-  type        = "SecureString"
-  value       = var.auth_saml_spPrivateKey
   description = "Value set by Terraform -- do not change manually."
 }
 

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -69,16 +69,6 @@ variable "auth_saml_spCertificate" {
   type        = string
 }
 
-variable "auth_saml_spPrivateKey" {
-  description = <<-EOT
-     Private cert data for this SP. If provided, it will be stored in SSM Parameter Store as a SecureString given.
-     Otherwise, the SSM parameter /idp-$${var.idp_name}/AUTH_SAML_spPrivateKey should be created and managed manually.
-  EOT
-  type        = string
-  default     = null
-  sensitive   = true
-}
-
 variable "cd_role_name" {
   description = "Name of the CD role to assume for deployments."
   type        = string


### PR DESCRIPTION
[IDP-1974](https://support.gtis.sil.org/issue/IDP-1974) move auth_saml_spPrivateKey to SSM

---

### Removed
- Removed the `auth_saml_spPrivateKey` variable and require that the key be added directly to SSM. This is the way most of our IdP instances have it set up already.

### Fixed
- Removing the `auth_saml_spPrivateKey` variable, which is sensitive, from the list of template keys. This was making the template sensitive, an oversight in #339 where this variable was first marked as sensitive.