### PR TITLE
corrections to README examples

### DIFF
--- a/modules/040-id-broker/README.md
+++ b/modules/040-id-broker/README.md
@@ -21,6 +21,7 @@ module "broker" {
 
   app_env                          = var.app_env
   app_name                         = var.app_name
+  cd_role_name                     = data.terraform_remote_state.core.cd_role_name
   cloudflare_domain                = var.cloudflare_domain
   cloudwatch_log_group_name        = var.cloudwatch_log_group_name
   contingent_user_duration         = var.contingent_user_duration
@@ -32,7 +33,6 @@ module "broker" {
   email_repeat_delay_days          = var.email_repeat_delay_days
   ecs_cluster_id                   = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn               = data.terraform_remote_state.core.ecsServiceRole_arn
-  task_execution_role_arn          = data.terraform_remote_state.core.task_execution_role_arn
   email_signature                  = var.email_signature
   event_schedule                   = "cron(1 0 * * ? 0)"
   google_config                    = var.google_config
@@ -113,6 +113,7 @@ module "broker" {
   subject_for_welcome              = var.subject_for_welcome
   support_email                    = var.support_email
   support_name                     = var.support_name
+  task_execution_role_arn          = data.terraform_remote_state.core.task_execution_role_arn
   vpc_id                           = data.terraform_remote_state.cluster.vpc_id
 }
 ```

--- a/modules/050-pw-manager/README.md
+++ b/modules/050-pw-manager/README.md
@@ -32,6 +32,7 @@ module "pwmanager" {
   auth_saml_requireEncryptedAssertion = var.auth_saml_requireEncryptedAssertion
   auth_saml_signRequest               = var.auth_saml_signRequest
   auth_saml_spCertificate             = var.auth_saml_spCertificate
+  cd_role_name                        = data.terraform_remote_state.core.cd_role_name
   cloudflare_domain                   = var.cloudflare_domain
   cloudwatch_log_group_name           = var.cloudwatch_log_group_name
   code_length                         = var.code_length
@@ -45,7 +46,6 @@ module "pwmanager" {
   email_signature                     = data.terraform_remote_state.broker.email_signature
   extra_hosts                         = var.extra_hosts
   help_center_url                     = data.terraform_remote_state.broker.help_center_url
-  id_broker_access_token              = data.terraform_remote_state.broker.access_token_pwmanager
   id_broker_assertValidBrokerIp       = var.id_broker_assertValidBrokerIp
   id_broker_base_uri                  = "https://${data.terraform_remote_state.broker.hostname}"
   id_broker_validIpRanges             = data.terraform_remote_state.cluster.private_subnet_cidr_blocks

--- a/modules/060-simplesamlphp/README.md
+++ b/modules/060-simplesamlphp/README.md
@@ -33,7 +33,6 @@ module "ssp" {
   password_change_url          = "https://${data.terraform_remote_state.pwmanager.ui_hostname}/#/password/create"
   password_forgot_url          = "https://${data.terraform_remote_state.pwmanager.ui_hostname}/#/password/forgot"
   hub_mode                     = var.hub_mode
-  id_broker_access_token       = data.terraform_remote_state.broker.access_token_ssp
   id_broker_assert_valid_ip    = var.id_broker_assert_valid_ip
   id_broker_base_uri           = "https://${data.terraform_remote_state.broker.hostname}"
   id_broker_trusted_ip_ranges  = data.terraform_remote_state.cluster.private_subnet_cidr_blocks
@@ -43,6 +42,7 @@ module "ssp" {
   mysql_host                   = data.terraform_remote_state.database.rds_address
   mysql_user                   = var.db_ssp_user
   profile_url                  = var.profile_url
+  cd_role_name                 = data.terraform_remote_state.core.cd_role_name
   ecs_cluster_id               = data.terraform_remote_state.core.ecs_cluster_id
   ecsServiceRole_arn           = data.terraform_remote_state.core.ecsServiceRole_arn
   task_execution_role_arn      = data.terraform_remote_state.core.task_execution_role_arn

--- a/modules/070-id-sync/README.md
+++ b/modules/070-id-sync/README.md
@@ -25,7 +25,6 @@ module "idsync" {
   alb_https_listener_arn      = data.terraform_remote_state.cluster.alb_https_listener_arn
   cloudwatch_log_group_name   = var.cloudwatch_log_group_name
   docker_image                = data.terraform_remote_state.ecr.ecr_repo_idsync
-  id_broker_access_token      = data.terraform_remote_state.broker.access_token_idsync
   id_broker_adapter           = var.id_broker_adapter
   id_broker_assertValidIp     = var.id_broker_assertValidIp
   id_broker_base_url          = "https://${data.terraform_remote_state.broker.hostname}"


### PR DESCRIPTION
[IDP-1979](https://support.gtis.sil.org/issue/IDP-1979) Move sensitive parameters to SSM

---

### Fixed
- Add `cd_role_name` and remove `id_broker_access_token` in README examples.