### PR TITLE
Add an option to create the ID Broker access key

### DIFF
--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -51,7 +51,9 @@ resource "aws_alb_listener_rule" "broker" {
   }
 }
 
-data "aws_ssm_parameter" "access_key" {
+data "aws_ssm_parameter" "id_broker_access_token" {
+  count = var.create_access_key ? 0 : 1
+
   name = "${local.parameter_store_path}ID_BROKER_ACCESS_TOKEN"
 }
 

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -55,6 +55,32 @@ data "aws_ssm_parameter" "access_key" {
   name = "${local.parameter_store_path}ID_BROKER_ACCESS_TOKEN"
 }
 
+resource "random_password" "access_key" {
+  count = var.create_access_key ? 1 : 0
+
+  length = 96
+}
+
+# define the parameter that other services use to access ID Broker
+resource "aws_ssm_parameter" "id_broker_access_token" {
+  count = var.create_access_key ? 1 : 0
+
+  name        = "${local.parameter_store_path}ID_BROKER_ACCESS_TOKEN"
+  type        = "SecureString"
+  value       = one(random_password.access_key[*].result)
+  description = "Value set by Terraform -- do not change manually."
+}
+
+# define the parameter that ID Broker uses to authenticate access keys used by other services
+resource "aws_ssm_parameter" "api_access_keys" {
+  count = var.create_access_key ? 1 : 0
+
+  name        = "${local.parameter_store_path}API_ACCESS_KEYS"
+  type        = "SecureString"
+  value       = one(random_password.access_key[*].result)
+  description = "Value set by Terraform -- do not change manually."
+}
+
 /*
  * Create ECS service
  */

--- a/modules/040-id-broker/outputs.tf
+++ b/modules/040-id-broker/outputs.tf
@@ -10,8 +10,12 @@ output "public_dns_value" {
 
 output "access_token_search" {
   description = "Access token for search lambda to use in API calls to id-broker. DEPRECATED: broker search is archived."
-  value       = var.create_access_key ? aws_ssm_parameter.access_key.value : data.aws_ssm_parameter.access_key.value
-  sensitive   = true
+  value = (
+    var.create_access_key
+    ? aws_ssm_parameter.id_broker_access_token[0].value
+    : data.aws_ssm_parameter.id_broker_access_token[0].value
+  )
+  sensitive = true
 }
 
 output "help_center_url" {

--- a/modules/040-id-broker/outputs.tf
+++ b/modules/040-id-broker/outputs.tf
@@ -10,7 +10,7 @@ output "public_dns_value" {
 
 output "access_token_search" {
   description = "Access token for search lambda to use in API calls to id-broker. DEPRECATED: broker search is archived."
-  value       = data.aws_ssm_parameter.access_key.value
+  value       = var.create_access_key ? aws_ssm_parameter.access_key.value : data.aws_ssm_parameter.access_key.value
   sensitive   = true
 }
 

--- a/modules/040-id-broker/test.tftest.hcl
+++ b/modules/040-id-broker/test.tftest.hcl
@@ -68,3 +68,19 @@ run "cd_role_attachment" {
     error_message = "cd role policy attachment is not attached to the correct role"
   }
 }
+
+run "create_access_key" {
+  variables {
+    create_access_key = true
+  }
+
+  assert {
+    condition     = length(aws_ssm_parameter.id_broker_access_token) > 0
+    error_message = "id_broker_access_token parameter should exist"
+  }
+
+  assert {
+    condition     = length(aws_ssm_parameter.api_access_keys) > 0
+    error_message = "api_access_keys parameter should exist"
+  }
+}

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -68,6 +68,12 @@ variable "cpu_email" {
   default     = 64
 }
 
+variable "create_access_key" {
+  description = "Set this flag to create and manage the access key used for the ID Broker API."
+  type        = bool
+  default     = false
+}
+
 variable "create_dns_record" {
   description = "Controls creation of a DNS CNAME record for the ECS service."
   type        = bool


### PR DESCRIPTION
[IDP-1979](https://support.gtis.sil.org/issue/IDP-1979) Move sensitive parameters to SSM

---

### Added
- Added `create_access_key` variable in the 040-id-broker module to provide the option to create and manage the access key in Terraform. Note: to use this feature, the existing SSM parameter must be deleted or imported into the state.