### PR TITLE
Remove sync s3 to b2

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -132,6 +132,9 @@ locals {
     sentry_dsn                = var.sentry_dsn
     service_mode              = var.service_mode
     parameter_store_path      = local.parameter_store_path
+    b2_bucket                 = var.b2_bucket
+    b2_application_key_id     = var.b2_application_key_id
+    b2_application_key        = var.b2_application_key
   })
 }
 
@@ -182,45 +185,3 @@ module "aws_backup" {
 }
 
 
-/*
- * Synchronize S3 bucket to Backblaze B2
- */
-module "s3_to_b2_sync" {
-  count = var.enable_s3_to_b2_sync ? 1 : 0
-
-  source  = "sil-org/sync-s3-to-b2/aws"
-  version = "~> 0.3.4"
-
-  app_name                  = "${var.idp_name}-${var.app_name}"
-  app_env                   = substr(var.app_env, 0, 4)
-  s3_bucket_name            = aws_s3_bucket.backup.bucket
-  s3_path                   = ""
-  b2_application_key_id_arn = one(aws_ssm_parameter.b2_application_key_id[*].arn)
-  b2_application_key_arn    = one(aws_ssm_parameter.b2_application_key[*].arn)
-  b2_bucket                 = var.b2_bucket
-  b2_path                   = var.b2_path
-  rclone_arguments          = var.rclone_arguments
-  log_group_name            = var.cloudwatch_log_group_name
-  ecs_cluster_id            = var.ecs_cluster_id
-  cpu                       = var.sync_cpu
-  memory                    = var.sync_memory
-  schedule                  = var.sync_schedule
-}
-
-resource "aws_ssm_parameter" "b2_application_key_id" {
-  count = var.enable_s3_to_b2_sync ? 1 : 0
-
-  name        = "${local.parameter_store_path}b2_application_key_id"
-  type        = "SecureString"
-  value       = var.b2_application_key_id
-  description = "Value set by Terraform -- do not change manually."
-}
-
-resource "aws_ssm_parameter" "b2_application_key" {
-  count = var.enable_s3_to_b2_sync ? 1 : 0
-
-  name        = "${local.parameter_store_path}b2_application_key"
-  type        = "SecureString"
-  value       = var.b2_application_key
-  description = "Value set by Terraform -- do not change manually."
-}

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -132,6 +132,8 @@ locals {
     sentry_dsn                = var.sentry_dsn
     service_mode              = var.service_mode
     parameter_store_path      = local.parameter_store_path
+    b2_application_key_id_arn = aws_ssm_parameter.b2_application_key_id.arn
+    b2_application_key_arn    = aws_ssm_parameter.b2_application_key.arn
     b2_bucket                 = var.b2_bucket
   })
 }

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -190,6 +190,12 @@ resource "aws_ssm_parameter" "b2_application_key_id" {
   type        = "SecureString"
   value       = var.b2_application_key_id
   description = "Value set by Terraform -- do not change manually."
+
+  tags = {
+    idp_name = var.idp_name
+    app_name = var.app_name
+    app_env  = var.app_env
+  }
 }
 
 resource "aws_ssm_parameter" "b2_application_key" {
@@ -197,4 +203,10 @@ resource "aws_ssm_parameter" "b2_application_key" {
   type        = "SecureString"
   value       = var.b2_application_key
   description = "Value set by Terraform -- do not change manually."
+
+  tags = {
+    idp_name = var.idp_name
+    app_name = var.app_name
+    app_env  = var.app_env
+  }
 }

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -133,8 +133,6 @@ locals {
     service_mode              = var.service_mode
     parameter_store_path      = local.parameter_store_path
     b2_bucket                 = var.b2_bucket
-    b2_application_key_id     = var.b2_application_key_id
-    b2_application_key        = var.b2_application_key
   })
 }
 
@@ -184,4 +182,19 @@ module "aws_backup" {
   delete_after           = var.delete_recovery_point_after_days
 }
 
+/*
+ * Backblaze B2 credentials in Parameter Store
+ */
+resource "aws_ssm_parameter" "b2_application_key_id" {
+  name        = "${local.parameter_store_path}B2_APPLICATION_KEY_ID"
+  type        = "SecureString"
+  value       = var.b2_application_key_id
+  description = "Value set by Terraform -- do not change manually."
+}
 
+resource "aws_ssm_parameter" "b2_application_key" {
+  name        = "${local.parameter_store_path}B2_APPLICATION_KEY"
+  type        = "SecureString"
+  value       = var.b2_application_key
+  description = "Value set by Terraform -- do not change manually."
+}

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -55,11 +55,11 @@
         },
         {
           "name": "B2_APPLICATION_KEY_ID",
-          "valueFrom": "${parameter_store_path}B2_APPLICATION_KEY_ID"
+          "valueFrom": "${b2_application_key_id_arn}"
         },
         {
           "name": "B2_APPLICATION_KEY",
-          "valueFrom": "${parameter_store_path}B2_APPLICATION_KEY"
+          "valueFrom": "${b2_application_key_arn}"
         }
     ],
     "links": null,

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -46,20 +46,20 @@
       {
         "name": "B2_BUCKET",
         "value": "${b2_bucket}"
-      },
-      {
-        "name": "B2_APPLICATION_KEY_ID",
-        "value": "${b2_application_key_id}"
-      },
-      {
-        "name": "B2_APPLICATION_KEY",
-        "value": "${b2_application_key}"
       }
     ],
     "secrets": [
         {
           "name": "MYSQL_PASSWORD",
           "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
+        },
+        {
+          "name": "B2_APPLICATION_KEY_ID",
+          "valueFrom": "${parameter_store_path}B2_APPLICATION_KEY_ID"
+        },
+        {
+          "name": "B2_APPLICATION_KEY",
+          "valueFrom": "${parameter_store_path}B2_APPLICATION_KEY"
         }
     ],
     "links": null,

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -42,6 +42,18 @@
       {
         "name": "SENTRY_DSN",
         "value": "${sentry_dsn}"
+      },
+      {
+        "name": "B2_BUCKET",
+        "value": "${b2_bucket}"
+      },
+      {
+        "name": "B2_APPLICATION_KEY_ID",
+        "value": "${b2_application_key_id}"
+      },
+      {
+        "name": "B2_APPLICATION_KEY",
+        "value": "${b2_application_key}"
       }
     ],
     "secrets": [

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -162,14 +162,8 @@ variable "sentry_dsn" {
 }
 
 /*
- * Synchronize S3 bucket to Backblaze B2
+ * Backblaze B2 backup
  */
-
-variable "enable_s3_to_b2_sync" {
-  description = "Whether to enable syncing S3 to B2"
-  type        = bool
-  default     = false
-}
 
 variable "b2_application_key_id" {
   description = "B2 Application Key ID for authentication"
@@ -188,36 +182,6 @@ variable "b2_bucket" {
   description = "Name of the B2 bucket for syncing data"
   type        = string
   default     = ""
-}
-
-variable "b2_path" {
-  description = "Path within the B2 bucket to sync data to"
-  type        = string
-  default     = ""
-}
-
-variable "rclone_arguments" {
-  description = "Additional arguments to pass to rclone"
-  type        = string
-  default     = "--transfers 4 --checkers 8"
-}
-
-variable "sync_cpu" {
-  description = "CPU units to allocate for the sync task"
-  type        = number
-  default     = 32
-}
-
-variable "sync_memory" {
-  description = "Memory to allocate for the sync task"
-  type        = number
-  default     = 32
-}
-
-variable "sync_schedule" {
-  description = "CloudWatch Events schedule expression for when to sync S3 to B2"
-  type        = string
-  default     = "cron(0 2 * * ? *)" // Example: Run at 2:00 AM UTC every day
 }
 
 variable "ssl_ca_base64" {

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -20,12 +20,8 @@ module "backup" {
   aws_backup_notification_events   = [""]
   backup_sns_email                 = ""
   delete_recovery_point_after_days = 7
-  enable_s3_to_b2_sync             = false
   b2_application_key_id            = ""
   b2_application_key               = ""
   b2_bucket                        = ""
-  rclone_arguments                 = "--transfers 4 --checkers 8"
-  b2_path                          = ""
-  sync_schedule                    = null
   task_execution_role_arn          = ""
 }


### PR DESCRIPTION
[IDP-1958](https://support.gtis.sil.org/issue/IDP-1958) combine backup and s3-to-b2 clone

---

### Changed
- Use the built-in backup option to copy to the B2 bucket in the mysql-backup-restore application.  

### Deprecated
- Removing the sync S3 to B2 as it's a redundant step, when we can achieve the same result using the existing backup application 

