### PR TITLE
Add enable_b2 flag to make B2 backup conditional

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -132,8 +132,9 @@ locals {
     sentry_dsn                = var.sentry_dsn
     service_mode              = var.service_mode
     parameter_store_path      = local.parameter_store_path
-    b2_application_key_id_arn = aws_ssm_parameter.b2_application_key_id.arn
-    b2_application_key_arn    = aws_ssm_parameter.b2_application_key.arn
+    enable_b2                 = var.enable_b2
+    b2_application_key_id_arn = one(aws_ssm_parameter.b2_application_key_id[*].arn)
+    b2_application_key_arn    = one(aws_ssm_parameter.b2_application_key[*].arn)
     b2_bucket                 = var.b2_bucket
   })
 }
@@ -188,6 +189,7 @@ module "aws_backup" {
  * Backblaze B2 credentials in Parameter Store
  */
 resource "aws_ssm_parameter" "b2_application_key_id" {
+  count       = var.enable_b2 ? 1 : 0
   name        = "${local.parameter_store_path}B2_APPLICATION_KEY_ID"
   type        = "SecureString"
   value       = var.b2_application_key_id
@@ -201,6 +203,7 @@ resource "aws_ssm_parameter" "b2_application_key_id" {
 }
 
 resource "aws_ssm_parameter" "b2_application_key" {
+  count       = var.enable_b2 ? 1 : 0
   name        = "${local.parameter_store_path}B2_APPLICATION_KEY"
   type        = "SecureString"
   value       = var.b2_application_key

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -9,6 +9,13 @@ locals {
     )
   )
   s3_backup_bucket = coalesce(var.s3_backup_bucket, "${var.idp_name}-${var.app_name}-${var.app_env}")
+  task_secrets = jsonencode(concat(
+    [{ name = "MYSQL_PASSWORD", valueFrom = "${local.parameter_store_path}MYSQL_PASSWORD" }],
+    var.enable_b2 ? [
+      { name = "B2_APPLICATION_KEY_ID", valueFrom = one(aws_ssm_parameter.b2_application_key_id[*].arn) },
+      { name = "B2_APPLICATION_KEY", valueFrom = one(aws_ssm_parameter.b2_application_key[*].arn) },
+    ] : []
+  ))
 }
 
 
@@ -131,10 +138,7 @@ locals {
     s3_bucket                 = aws_s3_bucket.backup.bucket
     sentry_dsn                = var.sentry_dsn
     service_mode              = var.service_mode
-    parameter_store_path      = local.parameter_store_path
-    enable_b2                 = var.enable_b2
-    b2_application_key_id_arn = one(aws_ssm_parameter.b2_application_key_id[*].arn)
-    b2_application_key_arn    = one(aws_ssm_parameter.b2_application_key[*].arn)
+    secrets                   = local.task_secrets
     b2_bucket                 = var.b2_bucket
   })
 }

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -52,7 +52,7 @@
         {
           "name": "MYSQL_PASSWORD",
           "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
-        },
+        }%{ if enable_b2 },
         {
           "name": "B2_APPLICATION_KEY_ID",
           "valueFrom": "${b2_application_key_id_arn}"
@@ -60,7 +60,7 @@
         {
           "name": "B2_APPLICATION_KEY",
           "valueFrom": "${b2_application_key_arn}"
-        }
+        }%{ endif }
     ],
     "links": null,
     "workingDirectory": null,

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -48,20 +48,7 @@
         "value": "${b2_bucket}"
       }
     ],
-    "secrets": [
-        {
-          "name": "MYSQL_PASSWORD",
-          "valueFrom": "${parameter_store_path}MYSQL_PASSWORD"
-        }%{ if enable_b2 },
-        {
-          "name": "B2_APPLICATION_KEY_ID",
-          "valueFrom": "${b2_application_key_id_arn}"
-        },
-        {
-          "name": "B2_APPLICATION_KEY",
-          "valueFrom": "${b2_application_key_arn}"
-        }%{ endif }
-    ],
+    "secrets": ${secrets},
     "links": null,
     "workingDirectory": null,
     "readonlyRootFilesystem": null,

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -184,6 +184,12 @@ variable "b2_bucket" {
   default     = ""
 }
 
+variable "enable_b2" {
+  description = "Whether to enable Backblaze B2 backup"
+  type        = bool
+  default     = false
+}
+
 variable "ssl_ca_base64" {
   description = "Database SSL CA PEM file, base64-encoded"
   type        = string


### PR DESCRIPTION
### Changed
- SSM parameters and ECS task secrets are now gated behind enable_b2 (default false), so customers not using B2 don't get empty credentials injected into their task definitions.
