### PR TITLE
Add b2_host to fix B2 backup endpoint error

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -140,6 +140,7 @@ locals {
     service_mode              = var.service_mode
     secrets                   = local.task_secrets
     b2_bucket                 = var.b2_bucket
+    b2_host                   = var.b2_host
   })
 }
 

--- a/modules/032-db-backup/task-definition.json.tftpl
+++ b/modules/032-db-backup/task-definition.json.tftpl
@@ -46,6 +46,10 @@
       {
         "name": "B2_BUCKET",
         "value": "${b2_bucket}"
+      },
+      {
+        "name": "B2_HOST",
+        "value": "${b2_host}"
       }
     ],
     "secrets": ${secrets},

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -190,6 +190,12 @@ variable "enable_b2" {
   default     = false
 }
 
+variable "b2_host" {
+  description = "B2 S3-compatible API endpoint URL (e.g. https://s3.us-west-004.backblazeb2.com)"
+  type        = string
+  default     = ""
+}
+
 variable "ssl_ca_base64" {
   description = "Database SSL CA PEM file, base64-encoded"
   type        = string

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -184,16 +184,16 @@ variable "b2_bucket" {
   default     = ""
 }
 
-variable "enable_b2" {
-  description = "Whether to enable Backblaze B2 backup"
-  type        = bool
-  default     = false
-}
-
 variable "b2_host" {
   description = "B2 S3-compatible API endpoint URL (e.g. https://s3.us-west-004.backblazeb2.com)"
   type        = string
   default     = ""
+}
+
+variable "enable_b2" {
+  description = "Whether to enable Backblaze B2 backup"
+  type        = bool
+  default     = false
 }
 
 variable "ssl_ca_base64" {


### PR DESCRIPTION
### Added
- Adds `b2_host` variable to pass `B2_HOST` into the task definition, fixing the `--endpoint-url "="` error caused by the backup script receiving no hostname for the B2 S3-compatible API