### PR TITLE
Add task-level memory and CPU to ECS service modules

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -177,7 +177,7 @@ module "aws_backup" {
   count = var.enable_aws_backup ? 1 : 0
 
   source  = "sil-org/backup/aws"
-  version = "~> 0.3.1"
+  version = "~> 0.3.0"
 
   app_name               = var.idp_name
   app_env                = var.app_env

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -177,7 +177,7 @@ module "aws_backup" {
   count = var.enable_aws_backup ? 1 : 0
 
   source  = "sil-org/backup/aws"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   app_name               = var.idp_name
   app_env                = var.app_env

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -208,7 +208,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -218,6 +218,8 @@ module "ecsservice" {
   desired_count      = var.desired_count
   task_role_arn      = module.ecs_role.role_arn
   execution_role_arn = var.task_execution_role_arn
+  memory             = var.task_memory
+  cpu                = var.task_cpu
 
   load_balancer = [{
     target_group_arn = aws_alb_target_group.broker.arn
@@ -275,7 +277,7 @@ locals {
 
 module "email_service" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-email"
@@ -284,6 +286,8 @@ module "email_service" {
   desired_count      = 1
   task_role_arn      = module.ecs_role.role_arn
   execution_role_arn = var.task_execution_role_arn
+  memory             = var.memory_email
+  cpu                = var.cpu_email
 }
 
 

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -208,7 +208,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.1"
+  version = "~> 0.3.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -277,7 +277,7 @@ locals {
 
 module "email_service" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.1"
+  version = "~> 0.3.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-email"

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -309,7 +309,7 @@ variable "task_memory" {
 }
 
 variable "task_cpu" {
-  description = "Task-level CPU reservation in CPU units for the web service. Optional for EC2; required for Fargate."
+  description = "Task-level CPU reservation in CPU units for the web service. Optional for EC2."
   type        = number
   default     = null
 }

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -302,6 +302,18 @@ variable "lost_security_key_email_days" {
   default     = 62
 }
 
+variable "task_memory" {
+  description = "Task-level memory limit in MB for the web service. Required for cgroup v2 (AL2023)."
+  type        = number
+  default     = null
+}
+
+variable "task_cpu" {
+  description = "Task-level CPU reservation in CPU units for the web service. Optional for EC2; required for Fargate."
+  type        = number
+  default     = null
+}
+
 variable "memory" {
   description = "Amount of memory to allocate to primary container."
   type        = number

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -303,7 +303,7 @@ variable "lost_security_key_email_days" {
 }
 
 variable "task_memory" {
-  description = "Task-level memory limit in MB for the web service. Required for cgroup v2 (AL2023)."
+  description = "Task-level memory limit in MiB for the web service. Required for cgroup v2 (AL2023)."
   type        = number
   default     = null
 }

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -117,7 +117,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -127,6 +127,8 @@ module "ecsservice" {
   ecsServiceRole_arn = var.ecsServiceRole_arn
   task_role_arn      = module.ecs_role.role_arn
   execution_role_arn = var.task_execution_role_arn
+  memory             = var.task_memory
+  cpu                = var.task_cpu
 
   load_balancer = [{
     target_group_arn = aws_alb_target_group.pwmanager.arn

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -117,7 +117,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.1"
+  version = "~> 0.3.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -175,6 +175,18 @@ variable "idp_name" {
   type        = string
 }
 
+variable "task_memory" {
+  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023)."
+  type        = number
+  default     = null
+}
+
+variable "task_cpu" {
+  description = "Task-level CPU reservation in CPU units. Optional for EC2; required for Fargate."
+  type        = number
+  default     = null
+}
+
 variable "kms_key_id" {
   description = <<-EOT
     Optional KMS key ID for SSM SecureString parameters. If used, it must have kms:Decrypt permission for all

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -182,7 +182,7 @@ variable "task_memory" {
 }
 
 variable "task_cpu" {
-  description = "Task-level CPU reservation in CPU units. Optional for EC2; required for Fargate."
+  description = "Task-level CPU reservation in CPU units. Optional for EC2."
   type        = number
   default     = null
 }

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -176,7 +176,7 @@ variable "idp_name" {
 }
 
 variable "task_memory" {
-  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023)."
+  description = "Task-level memory limit in MiB. Required for cgroup v2 (AL2023)."
   type        = number
   default     = null
 }

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -112,7 +112,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.1"
+  version = "~> 0.3.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -112,7 +112,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -122,6 +122,8 @@ module "ecsservice" {
   ecsServiceRole_arn = var.ecsServiceRole_arn
   task_role_arn      = module.ecs_role.role_arn
   execution_role_arn = var.task_execution_role_arn
+  memory             = var.task_memory
+  cpu                = var.task_cpu
 
   load_balancer = [{
     target_group_arn = aws_alb_target_group.ssp.arn

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -20,6 +20,18 @@ variable "memory" {
   default     = 96
 }
 
+variable "task_memory" {
+  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023)."
+  type        = number
+  default     = null
+}
+
+variable "task_cpu" {
+  description = "Task-level CPU reservation in CPU units. Optional for EC2; required for Fargate."
+  type        = number
+  default     = null
+}
+
 variable "cpu" {
   description = "CPU allocation for the container. Specified in AWS CPU units: 1000 is one CPU"
   type        = number

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -27,7 +27,7 @@ variable "task_memory" {
 }
 
 variable "task_cpu" {
-  description = "Task-level CPU reservation in CPU units. Optional for EC2; required for Fargate."
+  description = "Task-level CPU reservation in CPU units. Optional for EC2."
   type        = number
   default     = null
 }

--- a/modules/060-simplesamlphp/variables.tf
+++ b/modules/060-simplesamlphp/variables.tf
@@ -21,7 +21,7 @@ variable "memory" {
 }
 
 variable "task_memory" {
-  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023)."
+  description = "Task-level memory limit in MiB. Required for cgroup v2 (AL2023)."
   type        = number
   default     = null
 }


### PR DESCRIPTION
[ITSE-1860](https://support.gtis.sil.org/issue/ITSE-1860) Investigate why the IDPs had issue with AL2023

---

### Added

- Add task_memory variable to 040-id-broker, 050-pw-manager, and 060-simplesamlphp modules and pass it as the task-level memory on the ECS task definition — required for cgroup v2 (AL2023) to properly scope memory per task and prevent OOM kills
- Add task_cpu variable to the same modules and pass it as the task-level cpu on the ECS task definition — symmetric with task_memory and future-ready
- For 040-id-broker, task-level CPU is also wired to the email service task
- Both variables default to null — no behavior change for existing deployments on EC2