### PR TITLE
Fix email service task definition rejected by AWS

### DIFF
--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -286,7 +286,7 @@ module "email_service" {
   desired_count      = 1
   task_role_arn      = module.ecs_role.role_arn
   execution_role_arn = var.task_execution_role_arn
-  memory             = var.memory_email
+  memory             = var.email_task_memory
 }
 
 

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -287,7 +287,6 @@ module "email_service" {
   task_role_arn      = module.ecs_role.role_arn
   execution_role_arn = var.task_execution_role_arn
   memory             = var.memory_email
-  cpu                = var.cpu_email
 }
 
 

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -314,6 +314,12 @@ variable "task_cpu" {
   default     = null
 }
 
+variable "email_task_memory" {
+  description = "Task-level memory limit in MiB for the email service. Optional for EC2."
+  type        = number
+  default     = null
+}
+
 variable "memory" {
   description = "Amount of memory to allocate to primary container."
   type        = number

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -315,7 +315,7 @@ variable "task_cpu" {
 }
 
 variable "email_task_memory" {
-  description = "Task-level memory limit in MiB for the email service. Optional for EC2."
+  description = "Task-level memory limit in MiB for the email service. Required for cgroup v2 (AL2023)."
   type        = number
   default     = null
 }


### PR DESCRIPTION
### Changed
-  Remove `cpu = var.cpu_email` from the `email_service` module call in `040-id-broker`
- When ecs-service v0.3.1 added task-level `cpu` to `aws_ecs_task_definition`, the email service module call began passing `cpu_email` (50 units) as a task-level CPU boundary. AWS rejected this with "Invalid 'cpu' setting for task" because 50 is not a valid task-level CPU value
