### PR TITLE
add task-level memory to 070-id-sync

### DIFF
--- a/modules/070-id-sync/main.tf
+++ b/modules/070-id-sync/main.tf
@@ -66,6 +66,8 @@ resource "aws_ecs_task_definition" "cron_td" {
   network_mode          = "bridge"
   task_role_arn         = module.ecs_role.role_arn
   execution_role_arn    = var.task_execution_role_arn
+  memory                = var.task_memory
+  cpu                   = var.task_cpu
 }
 
 /*

--- a/modules/070-id-sync/variables.tf
+++ b/modules/070-id-sync/variables.tf
@@ -7,6 +7,18 @@ variable "memory" {
   default     = 200
 }
 
+variable "task_memory" {
+  description = "Task-level memory limit in MiB. Required for cgroup v2 (AL2023) to properly scope memory per task."
+  type        = number
+  default     = null
+}
+
+variable "task_cpu" {
+  description = "Task-level CPU reservation in CPU units. Optional for EC2."
+  type        = number
+  default     = null
+}
+
 variable "cpu" {
   description = "CPU allocation for the container. Specified in AWS CPU units: 1000 is one CPU"
   type        = number


### PR DESCRIPTION
### Added
- Add `task_memory` and `task_cpu` variables to `070-id-sync` module
- Set task-level `memory` and `cpu` on `aws_ecs_task_definition`
