### PR TITLE
add task-level memory and cpu parameters for db-backup

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -168,6 +168,8 @@ resource "aws_ecs_task_definition" "cron_td" {
   network_mode          = "bridge"
   execution_role_arn    = var.task_execution_role_arn
   task_role_arn         = aws_iam_role.backup.arn
+  memory                = var.task_memory
+  cpu                   = var.task_cpu
 }
 
 /*

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -118,12 +118,24 @@ variable "service_mode" {
   default     = "backup"
 }
 
+variable "task_cpu" {
+  description = "Task-level CPU reservation in CPU units. Optional for EC2."
+  type        = number
+  default     = null
+}
+
 variable "task_execution_role_arn" {
   description = <<-EOT
     ARN of the IAM role that ECS will use to execute the backup task. It must have permission to read parameters from
     SSM Parameter Store.
   EOT
   type        = string
+}
+
+variable "task_memory" {
+  description = "Task-level memory limit in MiB. Required for cgroup v2 (AL2023) to properly scope memory per task."
+  type        = number
+  default     = null
 }
 
 /*


### PR DESCRIPTION
[ITSE-1860](https://support.gtis.sil.org/issue/ITSE-1860) Investigate why the IDPs had issue with AL2023

---

### Added
- Add `task_memory` and `task_cpu` variables to `032-db-backup` module and set task-level `memory` and `cpu` on `aws_ecs_task_definition`.
