### PR TITLE
allow the WebAuthn RP ID to be configured separately from the IdP domain

### DIFF
--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -151,7 +151,7 @@ locals {
     mfa_webauthn_apibaseurl                    = var.mfa_api_base_url
     rp_origins                                 = var.rp_origins
     minimum_backup_codes_before_nag            = var.minimum_backup_codes_before_nag
-    mfa_webauthn_rpid                          = var.cloudflare_domain
+    mfa_webauthn_rp_id                         = coalesce(var.mfa_webauthn_rp_id, var.cloudflare_domain)
     mysql_host                                 = var.mysql_host
     mysql_user                                 = var.mysql_user
     name                                       = "web"

--- a/modules/040-id-broker/task-definition.json.tftpl
+++ b/modules/040-id-broker/task-definition.json.tftpl
@@ -187,7 +187,7 @@
       },
       {
         "name": "MFA_WEBAUTHN_rpId",
-        "value": "${mfa_webauthn_rpid}"
+        "value": "${mfa_webauthn_rp_id}"
       },
       {
         "name": "RP_ORIGINS",

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -410,6 +410,19 @@ variable "mfa_required_for_new_users" {
   default     = false
 }
 
+variable "mfa_webauthn_rp_id" {
+  description = <<-EOT
+    The Relying Party ID (RP ID) for WebAuthn. This should generally be the base domain of the IdP URL,
+    e.g. `example.com` if your IdP is at `https://login.example.com`. If it is different, a .well-known/webauthn file
+    should be served at the RP ID domain (Refer to https://passkeys.dev/docs/advanced/related-origins/.) The content of
+    the `origins` list in this file should include the base URL of the profile manager (`var.password_profile_url`)
+    and the base URL of the SimpleSAMLphp server (`"https://$${var.subdomain}.$${var.cloudflare_domain}"` as defined
+    in the 060-simplesamlphp module). If `mfa_webauthn_rp_id` is not set, the RP ID will be the value of
+    `cloudflare_domain`.
+  EOT
+  default     = null
+}
+
 variable "rp_origins" {
   description = "CSV list of allowed Webauthn Relying Party Origins"
   type        = string

--- a/modules/040-id-broker/variables.tf
+++ b/modules/040-id-broker/variables.tf
@@ -420,6 +420,7 @@ variable "mfa_webauthn_rp_id" {
     in the 060-simplesamlphp module). If `mfa_webauthn_rp_id` is not set, the RP ID will be the value of
     `cloudflare_domain`.
   EOT
+  type        = string
   default     = null
 }
 


### PR DESCRIPTION
[IDP-1983](https://support.gtis.sil.org/issue/IDP-1983) Try to move appsdev IdP to gtis.guru (again)

---

### Added
- Added a new input to 040-id-broker to allow the WebAuthn Relying Party ID (RP ID) to be set separately from the IdP domain (`cloudflare_domain`).