### PR TITLE
Release 16.0.0-pre.3 -- update ami_name_filter default

### DIFF
--- a/modules/010-cluster/variables.tf
+++ b/modules/010-cluster/variables.tf
@@ -1,7 +1,7 @@
 variable "ami_name_filter" {
   description = "Filter to identify the EC2 AMI to be used in the autoscaling group. The most recent match is used."
   type        = list(string)
-  default     = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
+  default     = ["al2023-ami-ecs-hvm-*-x86_64"]
 }
 
 variable "app_name" {


### PR DESCRIPTION
[IDP-1470](https://support.gtis.sil.org/issue/IDP-1470) Change the ASG image template to AL2023

---

### Changed

- update ami_name_filter default value to al2023-ami-ecs-hvm-*-x86_64