### PR TITLE
restrict iam:PassRole to allow only the required roles

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -146,7 +146,7 @@ locals {
 
 module "backup_task" {
   source  = "sil-org/scheduled-ecs-task/aws"
-  version = "~> 0.1.1"
+  version = "~> 1.0"
 
   name                   = "${var.idp_name}-${var.app_name}-${var.app_env}"
   event_rule_description = "Start scheduled backup"

--- a/modules/032-db-backup/test.tftest.hcl
+++ b/modules/032-db-backup/test.tftest.hcl
@@ -9,6 +9,11 @@ mock_provider "aws" {
       arn = "arn:aws:ecs:us-east-1:111111111111:task-definition/test-task-definition:1"
     }
   }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{}"
+    }
+  }
 }
 
 variables {

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -230,7 +230,7 @@ module "ecsservice" {
 
 module "cron_task" {
   source  = "sil-org/scheduled-ecs-task/aws"
-  version = "~> 0.1"
+  version = "~> 1.0"
 
   name                   = "${var.idp_name}-${var.app_name}-cron-${var.app_env}-${local.aws_region}"
   event_rule_description = "Start broker scheduled tasks"

--- a/modules/040-id-broker/test.tftest.hcl
+++ b/modules/040-id-broker/test.tftest.hcl
@@ -20,6 +20,11 @@ mock_provider "aws" {
       arn = "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/test-tg"
     }
   }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{}"
+    }
+  }
 }
 
 mock_provider "cloudflare" {}

--- a/modules/070-id-sync/main.tf
+++ b/modules/070-id-sync/main.tf
@@ -43,7 +43,7 @@ locals {
 
 module "cron_task" {
   source  = "sil-org/scheduled-ecs-task/aws"
-  version = "~> 0.1"
+  version = "~> 1.0"
 
   name                   = "${var.idp_name}-${var.app_name}-cron-${var.app_env}-${local.aws_region}"
   event_rule_description = "Start ID Sync scheduled tasks"

--- a/modules/070-id-sync/test.tftest.hcl
+++ b/modules/070-id-sync/test.tftest.hcl
@@ -9,6 +9,11 @@ mock_provider "aws" {
       arn = "arn:aws:ecs:us-east-1:111111111111:task-definition/test-task-definition:1"
     }
   }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{}"
+    }
+  }
 }
 
 variables {


### PR DESCRIPTION
[ITSE-2843](https://support.gtis.sil.org/issue/ITSE-2843) Restrict roles on all iam:PassRole policies

### Security
- Update scheduled-ecs-task module to restrict the `iam:PassRole` to allow only the necessary roles.
