### PR TITLE
update Cloudflare provider to latest 4.x version in preparation for 5.x

### DIFF
--- a/modules/040-id-broker/versions.tf
+++ b/modules/040-id-broker/versions.tf
@@ -7,11 +7,8 @@ terraform {
       version = ">= 4.0.0, < 6.0.0"
     }
     cloudflare = {
-      source = "cloudflare/cloudflare"
-
-      // 4.39.0 deprecated cloudflare_record.value
-      // While waiting for version 5 to mature, we'll constrain to earlier versions.
-      version = ">= 2.0.0, < 4.39.0"
+      source  = "cloudflare/cloudflare"
+      version = ">= 2.0.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/050-pw-manager/versions.tf
+++ b/modules/050-pw-manager/versions.tf
@@ -7,11 +7,8 @@ terraform {
       version = ">= 4.0.0, < 6.0.0"
     }
     cloudflare = {
-      source = "cloudflare/cloudflare"
-
-      // 4.39.0 deprecated cloudflare_record.value
-      // While waiting for version 5 to mature, we'll constrain to earlier versions.
-      version = ">= 2.0.0, < 4.39.0"
+      source  = "cloudflare/cloudflare"
+      version = ">= 2.0.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/060-simplesamlphp/versions.tf
+++ b/modules/060-simplesamlphp/versions.tf
@@ -7,11 +7,8 @@ terraform {
       version = ">= 4.0.0, < 6.0.0"
     }
     cloudflare = {
-      source = "cloudflare/cloudflare"
-
-      // 4.39.0 deprecated cloudflare_record.value
-      // While waiting for version 5 to mature, we'll constrain to earlier versions.
-      version = ">= 2.0.0, < 4.39.0"
+      source  = "cloudflare/cloudflare"
+      version = ">= 2.0.0, < 5.0.0"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
[ITSE-2706](https://support.gtis.sil.org/issue/ITSE-2706) Update Terraform AWS provider to 6.x

---

### Changed
- Update Cloudflare provider to latest 4.x version in preparation for 5.x
