### PR TITLE
Release 16.0.0-pre.1 -- Upgrade Terraform and providers

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     uses: sil-org/workflows/.github/workflows/terraform.yml@main
     with:
-      terraform-version: '~> 1.5'
+      terraform-version: '~> 1.8'
       test-dir: test
 
   tftest:
@@ -19,11 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # Install Terraform 1.7, which is the earliest that supports `terraform test`.
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.7.5"
+          terraform_version: "~> 1.8"
 
       - name: Test
         run: ./test.sh

--- a/modules/010-cluster/main.tf
+++ b/modules/010-cluster/main.tf
@@ -108,7 +108,7 @@ data "aws_acm_certificate" "wildcard" {
  */
 module "alb" {
   source  = "sil-org/alb/aws"
-  version = "~> 1.1"
+  version = "~> 2.0"
 
   app_name            = var.app_name
   app_env             = var.app_env
@@ -126,7 +126,7 @@ module "alb" {
  */
 module "internal_alb" {
   source  = "sil-org/alb/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   alb_name        = "alb-${var.app_name}-${var.app_env}-int"
   app_name        = var.app_name
@@ -159,10 +159,10 @@ module "ecs-service-cloudwatch-dashboard" {
   count = var.create_dashboard ? 1 : 0
 
   source  = "sil-org/ecs-service-cloudwatch-dashboard/aws"
-  version = "~> 3.1"
+  version = "~> 4.0"
 
   cluster_name   = var.ecs_cluster_name
-  dashboard_name = "${var.app_name}-${var.app_env}-${data.aws_region.current.name}"
+  dashboard_name = "${var.app_name}-${var.app_env}-${data.aws_region.current.region}"
 
   service_names = [
     "${var.idp_name}-id-broker",

--- a/modules/010-cluster/versions.tf
+++ b/modules/010-cluster/versions.tf
@@ -1,14 +1,14 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
     external = {
       source  = "hashicorp/external"
-      version = ">= 2.0.0, < 3.0.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/modules/010-cluster/versions.tf
+++ b/modules/010-cluster/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.8"
+  required_version = "~> 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_account          = data.aws_caller_identity.this.account_id
-  aws_region           = data.aws_region.current.name
+  aws_region           = data.aws_region.current.region
   parameter_store_path = "/idp-${var.idp_name}/"
   rds_arn = (
     coalesce(
@@ -146,7 +146,7 @@ locals {
 
 module "backup_task" {
   source  = "sil-org/scheduled-ecs-task/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   name                   = "${var.idp_name}-${var.app_name}-${var.app_env}"
   event_rule_description = "Start scheduled backup"
@@ -179,7 +179,7 @@ module "aws_backup" {
   count = var.enable_aws_backup ? 1 : 0
 
   source  = "sil-org/backup/aws"
-  version = "~> 0.3.1"
+  version = "~> 1.0"
 
   app_name               = var.idp_name
   app_env                = var.app_env

--- a/modules/032-db-backup/versions.tf
+++ b/modules/032-db-backup/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/040-id-broker/main.tf
+++ b/modules/040-id-broker/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_account          = data.aws_caller_identity.this.account_id
-  aws_region           = data.aws_region.current.name
+  aws_region           = data.aws_region.current.region
   parameter_store_path = "/idp-${var.idp_name}/"
 }
 
@@ -12,7 +12,7 @@ resource "aws_alb_target_group" "broker" {
   port                 = var.enable_tls ? 443 : 80
   protocol             = var.enable_tls ? "HTTPS" : "HTTP"
   vpc_id               = var.vpc_id
-  deregistration_delay = "30"
+  deregistration_delay = 30
 
   stickiness {
     type = "lb_cookie"
@@ -30,7 +30,7 @@ resource "aws_alb_target_group" "broker" {
  */
 resource "aws_alb_listener_rule" "broker" {
   listener_arn = coalesce(var.internal_alb_listener_arn, var.alb_listener_arn)
-  priority     = "40"
+  priority     = 40
 
   action {
     target_group_arn = aws_alb_target_group.broker.arn
@@ -208,7 +208,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 1.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -224,13 +224,13 @@ module "ecsservice" {
   load_balancer = [{
     target_group_arn = aws_alb_target_group.broker.arn
     container_name   = "web"
-    container_port   = var.enable_tls ? "443" : "80"
+    container_port   = var.enable_tls ? 443 : 80
   }]
 }
 
 module "cron_task" {
   source  = "sil-org/scheduled-ecs-task/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   name                   = "${var.idp_name}-${var.app_name}-cron-${var.app_env}-${local.aws_region}"
   event_rule_description = "Start broker scheduled tasks"
@@ -277,7 +277,7 @@ locals {
 
 module "email_service" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 1.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}-email"
@@ -293,30 +293,45 @@ module "email_service" {
 /*
  * Create Cloudflare DNS record(s)
  */
-resource "cloudflare_record" "public" {
+resource "cloudflare_dns_record" "public" {
   count = var.create_dns_record ? 1 : 0
 
   zone_id = data.cloudflare_zone.domain.id
   name    = var.subdomain
-  value   = cloudflare_record.brokerdns.hostname
+  content = cloudflare_dns_record.brokerdns.name
   type    = "CNAME"
   proxied = true
+  ttl     = 1
 }
 
-resource "cloudflare_record" "brokerdns" {
+moved {
+  from = cloudflare_record.public
+  to   = cloudflare_dns_record.public
+}
+
+resource "cloudflare_dns_record" "brokerdns" {
   zone_id = data.cloudflare_zone.domain.id
   name    = local.subdomain_with_region
-  value   = coalesce(var.internal_alb_dns_name, var.alb_dns_name)
+  content = coalesce(var.internal_alb_dns_name, var.alb_dns_name)
   type    = "CNAME"
 
   # If the internal ALB DNS name is not specified, this should be proxied to bridge between IPv4 and IPv6. Outbound
   # connections only support IPv4, for reasons not well understood by me. Inbound connections only support IPv6 by
   # design, to decrease AWS costs.
   proxied = var.internal_alb_dns_name == ""
+  ttl     = 1
 }
 
+moved {
+  from = cloudflare_record.brokerdns
+  to   = cloudflare_dns_record.brokerdns
+}
+
+
 data "cloudflare_zone" "domain" {
-  name = var.cloudflare_domain
+  filter = {
+    name = var.cloudflare_domain
+  }
 }
 
 

--- a/modules/040-id-broker/outputs.tf
+++ b/modules/040-id-broker/outputs.tf
@@ -5,7 +5,7 @@ output "hostname" {
 
 output "public_dns_value" {
   description = "The value to use for the 'public' DNS record, if creating it outside of this module."
-  value       = cloudflare_record.brokerdns.hostname
+  value       = "${cloudflare_dns_record.brokerdns.name}.${var.cloudflare_domain}"
 }
 
 output "access_token_search" {

--- a/modules/040-id-broker/versions.tf
+++ b/modules/040-id-broker/versions.tf
@@ -1,14 +1,14 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 2.0.0, < 5.0.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/040-id-broker/versions.tf
+++ b/modules/040-id-broker/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.8"
+  required_version = "~> 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_account          = data.aws_caller_identity.this.account_id
-  aws_region           = data.aws_region.current.name
+  aws_region           = data.aws_region.current.region
   ui_hostname          = "${var.ui_subdomain}.${var.cloudflare_domain}"
   parameter_store_path = "/idp-${var.idp_name}/"
 }
@@ -13,7 +13,7 @@ resource "aws_alb_target_group" "pwmanager" {
   port                 = var.enable_tls ? 443 : 80
   protocol             = var.enable_tls ? "HTTPS" : "HTTP"
   vpc_id               = var.vpc_id
-  deregistration_delay = "30"
+  deregistration_delay = 30
 
   stickiness {
     type = "lb_cookie"
@@ -31,7 +31,7 @@ resource "aws_alb_target_group" "pwmanager" {
  */
 resource "aws_alb_listener_rule" "pwmanager" {
   listener_arn = var.alb_https_listener_arn
-  priority     = "50"
+  priority     = 50
 
   action {
     type             = "forward"
@@ -117,7 +117,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 1.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -133,33 +133,48 @@ module "ecsservice" {
   load_balancer = [{
     target_group_arn = aws_alb_target_group.pwmanager.arn
     container_name   = "web"
-    container_port   = var.enable_tls ? "443" : "80"
+    container_port   = var.enable_tls ? 443 : 80
   }]
 }
 
 /*
  * Create Cloudflare DNS record(s)
  */
-resource "cloudflare_record" "apidns" {
+resource "cloudflare_dns_record" "apidns" {
   count = var.create_dns_record ? 1 : 0
 
   zone_id = data.cloudflare_zone.domain.id
   name    = var.api_subdomain
-  value   = cloudflare_record.apidns_intermediate.hostname
+  content = cloudflare_dns_record.apidns_intermediate.name
   type    = "CNAME"
   proxied = true
+  ttl     = 1
 }
 
-resource "cloudflare_record" "apidns_intermediate" {
+moved {
+  from = cloudflare_record.apidns
+  to   = cloudflare_dns_record.apidns
+}
+
+resource "cloudflare_dns_record" "apidns_intermediate" {
   zone_id = data.cloudflare_zone.domain.id
   name    = local.api_subdomain_with_region
-  value   = var.alb_dns_name
+  content = var.alb_dns_name
   type    = "CNAME"
   proxied = true
+  ttl     = 1
 }
 
+moved {
+  from = cloudflare_record.apidns_intermediate
+  to   = cloudflare_dns_record.apidns_intermediate
+}
+
+
 data "cloudflare_zone" "domain" {
-  name = var.cloudflare_domain
+  filter = {
+    name = var.cloudflare_domain
+  }
 }
 
 

--- a/modules/050-pw-manager/outputs.tf
+++ b/modules/050-pw-manager/outputs.tf
@@ -5,5 +5,5 @@ output "ui_hostname" {
 
 output "api_public_dns_value" {
   description = "The value to use for the 'public' DNS record, if creating it outside of this module."
-  value       = cloudflare_record.apidns_intermediate.hostname
+  value       = "${cloudflare_dns_record.apidns.name}.${var.cloudflare_domain}"
 }

--- a/modules/050-pw-manager/outputs.tf
+++ b/modules/050-pw-manager/outputs.tf
@@ -5,5 +5,5 @@ output "ui_hostname" {
 
 output "api_public_dns_value" {
   description = "The value to use for the 'public' DNS record, if creating it outside of this module."
-  value       = "${cloudflare_dns_record.apidns.name}.${var.cloudflare_domain}"
+  value       = "${cloudflare_dns_record.apidns_intermediate.name}.${var.cloudflare_domain}"
 }

--- a/modules/050-pw-manager/versions.tf
+++ b/modules/050-pw-manager/versions.tf
@@ -1,14 +1,14 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 2.0.0, < 5.0.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/050-pw-manager/versions.tf
+++ b/modules/050-pw-manager/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.8"
+  required_version = "~> 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/060-simplesamlphp/main.tf
+++ b/modules/060-simplesamlphp/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_account          = data.aws_caller_identity.this.account_id
-  aws_region           = data.aws_region.current.name
+  aws_region           = data.aws_region.current.region
   parameter_store_path = "/idp-${var.idp_name}/"
 }
 
@@ -12,7 +12,7 @@ resource "aws_alb_target_group" "ssp" {
   port                 = var.enable_tls ? 443 : 80
   protocol             = var.enable_tls ? "HTTPS" : "HTTP"
   vpc_id               = var.vpc_id
-  deregistration_delay = "30"
+  deregistration_delay = 30
 
   health_check {
     path     = "/module.php/silauth/status.php"
@@ -26,7 +26,7 @@ resource "aws_alb_target_group" "ssp" {
  */
 resource "aws_alb_listener_rule" "ssp" {
   listener_arn = var.alb_https_listener_arn
-  priority     = "60"
+  priority     = 60
 
   action {
     type             = "forward"
@@ -112,7 +112,7 @@ locals {
 
 module "ecsservice" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 1.0"
 
   cluster_id         = var.ecs_cluster_id
   service_name       = "${var.idp_name}-${var.app_name}"
@@ -128,33 +128,48 @@ module "ecsservice" {
   load_balancer = [{
     target_group_arn = aws_alb_target_group.ssp.arn
     container_name   = "web"
-    container_port   = var.enable_tls ? "443" : "80"
+    container_port   = var.enable_tls ? 443 : 80
   }]
 }
 
 /*
  * Create Cloudflare DNS record(s)
  */
-resource "cloudflare_record" "sspdns" {
+resource "cloudflare_dns_record" "sspdns" {
   count = var.create_dns_record ? 1 : 0
 
   zone_id = data.cloudflare_zone.domain.id
   name    = var.subdomain
-  value   = cloudflare_record.sspdns_intermediate.hostname
+  content = cloudflare_dns_record.sspdns_intermediate.name
   type    = "CNAME"
   proxied = true
+  ttl     = 1
 }
 
-resource "cloudflare_record" "sspdns_intermediate" {
+moved {
+  from = cloudflare_record.sspdns
+  to   = cloudflare_dns_record.sspdns
+}
+
+resource "cloudflare_dns_record" "sspdns_intermediate" {
   zone_id = data.cloudflare_zone.domain.id
   name    = local.subdomain_with_region
-  value   = var.alb_dns_name
+  content = var.alb_dns_name
   type    = "CNAME"
   proxied = true
+  ttl     = 1
 }
 
+moved {
+  from = cloudflare_record.sspdns_intermediate
+  to   = cloudflare_dns_record.sspdns_intermediate
+}
+
+
 data "cloudflare_zone" "domain" {
-  name = var.cloudflare_domain
+  filter = {
+    name = var.cloudflare_domain
+  }
 }
 
 

--- a/modules/060-simplesamlphp/outputs.tf
+++ b/modules/060-simplesamlphp/outputs.tf
@@ -16,5 +16,5 @@ output "secret_salt" {
 
 output "public_dns_value" {
   description = "The value to use for the 'public' DNS record, if creating it outside of this module."
-  value       = "${cloudflare_dns_record.sspdns.name}.${var.cloudflare_domain}"
+  value       = "${cloudflare_dns_record.sspdns_intermediate.name}.${var.cloudflare_domain}"
 }

--- a/modules/060-simplesamlphp/outputs.tf
+++ b/modules/060-simplesamlphp/outputs.tf
@@ -16,5 +16,5 @@ output "secret_salt" {
 
 output "public_dns_value" {
   description = "The value to use for the 'public' DNS record, if creating it outside of this module."
-  value       = cloudflare_record.sspdns_intermediate.hostname
+  value       = "${cloudflare_dns_record.sspdns.name}.${var.cloudflare_domain}"
 }

--- a/modules/060-simplesamlphp/versions.tf
+++ b/modules/060-simplesamlphp/versions.tf
@@ -1,18 +1,18 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 2.0.0, < 5.0.0"
+      version = "~> 5.0"
     }
     external = {
       source  = "hashicorp/external"
-      version = ">= 2.0.0, < 3.0.0"
+      version = "~> 2.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/060-simplesamlphp/versions.tf
+++ b/modules/060-simplesamlphp/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.8"
+  required_version = "~> 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/070-id-sync/main.tf
+++ b/modules/070-id-sync/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_account          = data.aws_caller_identity.this.account_id
-  aws_region           = data.aws_region.current.name
+  aws_region           = data.aws_region.current.region
   parameter_store_path = "/idp-${var.idp_name}/"
 
   /*
@@ -43,7 +43,7 @@ locals {
 
 module "cron_task" {
   source  = "sil-org/scheduled-ecs-task/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   name                   = "${var.idp_name}-${var.app_name}-cron-${var.app_env}-${local.aws_region}"
   event_rule_description = "Start ID Sync scheduled tasks"

--- a/modules/070-id-sync/versions.tf
+++ b/modules/070-id-sync/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.8"
+  required_version = "~> 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/070-id-sync/versions.tf
+++ b/modules/070-id-sync/versions.tf
@@ -1,10 +1,10 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/ecs-role/main.tf
+++ b/modules/ecs-role/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_account = data.aws_caller_identity.this.account_id
-  aws_region  = data.aws_region.current.name
+  aws_region  = data.aws_region.current.region
 }
 
 /*

--- a/modules/ecs-role/versions.tf
+++ b/modules/ecs-role/versions.tf
@@ -1,10 +1,10 @@
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/ecs-role/versions.tf
+++ b/modules/ecs-role/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.8"
+  required_version = "~> 1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
[ITSE-2706](https://support.gtis.sil.org/issue/ITSE-2706) Update Terraform AWS provider to 6.x

---

### Changed (BREAKING)
- Require Terraform version 1.8 or later to support the Cloudflare provider upgrade.
- Require AWS provider version 6. The aws_region data source removed `name` in version 6.
- Require Cloudflare provider version 5. The cloudflare_record resource was removed in version 5.
