### PR TITLE
remove unused variables

### DIFF
--- a/modules/032-db-backup/main.tf
+++ b/modules/032-db-backup/main.tf
@@ -130,7 +130,7 @@ locals {
     aws_region                = local.aws_region
     cloudwatch_log_group_name = var.cloudwatch_log_group_name
     cpu                       = var.cpu
-    db_names                  = join(" ", var.db_names)
+    db_names                  = "idbroker ssp"
     docker_image              = var.docker_image
     mysql_host                = var.mysql_host
     mysql_user                = var.mysql_user

--- a/modules/032-db-backup/variables.tf
+++ b/modules/032-db-backup/variables.tf
@@ -29,15 +29,6 @@ variable "cpu" {
   default     = 64
 }
 
-variable "db_names" {
-  description = "List of database names to back up."
-  type        = list(string)
-  default = [
-    "idbroker",
-    "ssp",
-  ]
-}
-
 variable "docker_image" {
   description = "The docker image to use for scheduled backup"
   type        = string

--- a/modules/050-pw-manager/main.tf
+++ b/modules/050-pw-manager/main.tf
@@ -85,7 +85,6 @@ locals {
     cpu                                 = var.cpu
     docker_image                        = var.docker_image
     email_signature                     = var.email_signature
-    extra_hosts                         = var.extra_hosts
     help_center_url                     = var.help_center_url
     id_broker_assertValidBrokerIp       = var.id_broker_assertValidBrokerIp
     id_broker_base_uri                  = var.id_broker_base_uri

--- a/modules/050-pw-manager/task-definition-api.json.tftpl
+++ b/modules/050-pw-manager/task-definition-api.json.tftpl
@@ -2,7 +2,6 @@
   {
     "volumesFrom": [],
     "memory": ${memory},
-    "extraHosts": ${extra_hosts},
     "dnsServers": null,
     "disableNetworking": null,
     "dnsSearchDomains": null,

--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -128,12 +128,6 @@ variable "email_signature" {
   type        = string
 }
 
-variable "extra_hosts" {
-  description = "Extra hosts for the API task definition, e.g. [\"host.example.com:192.168.1.1\"]"
-  type        = string
-  default     = "null"
-}
-
 variable "help_center_url" {
   type = string
 }

--- a/test/032-db-backup.tf
+++ b/test/032-db-backup.tf
@@ -7,7 +7,6 @@ module "backup" {
   cloudwatch_log_group_name        = ""
   cpu                              = 1
   event_schedule                   = ""
-  db_names                         = [""]
   docker_image                     = ""
   ecs_cluster_id                   = ""
   idp_name                         = ""

--- a/test/050-pw-manager.tf
+++ b/test/050-pw-manager.tf
@@ -22,7 +22,6 @@ module "pw" {
   ecsServiceRole_arn                  = ""
   ecs_cluster_id                      = ""
   email_signature                     = ""
-  extra_hosts                         = ""
   help_center_url                     = ""
   id_broker_assertValidBrokerIp       = true
   id_broker_base_uri                  = ""


### PR DESCRIPTION

### Removed
- Removed unused variables:
  - 032-db-backup: `db_names` is always set to back up every database.
  - 050-pw-manager: `extra_hosts` was used by an IdP instance that is no longer in service to handle an unusual firewall configuration for their Active Directory server.