### PR TITLE
reduce password_rule_maxlength default to 72 (limited by bcrypt)

### DIFF
--- a/modules/050-pw-manager/variables.tf
+++ b/modules/050-pw-manager/variables.tf
@@ -200,7 +200,7 @@ variable "password_rule_enablehibp" {
 variable "password_rule_maxlength" {
   description = "maximum password length"
   type        = number
-  default     = 255
+  default     = 72
 }
 
 variable "password_rule_minlength" {


### PR DESCRIPTION
[IDP-2185](https://support.gtis.sil.org/issue/IDP-2185) Verify and fix bcrypt use in idp-id-broker

---

### Changed
- Reduced `password_rule_maxlength` default to 72. Password length is limited by bcrypt hashing, so any password over 72 characters is truncated silently.